### PR TITLE
fix(ammo): update AmmoPickup network message serialization to 5 bytes

### DIFF
--- a/scripts/maps/bts_rc/entities/ammo/main.as
+++ b/scripts/maps/bts_rc/entities/ammo/main.as
@@ -34,7 +34,7 @@ class BTS_Ammo : BTS_Item
             {
                 NetworkMessage msg( MSG_ONE, NetworkMessages::AmmoPickup, player.edict() );
                     msg.WriteByte( g_PlayerFuncs.GetAmmoIndex( ammoName ) );
-                    msg.WriteByte( finalGive );
+                    msg.WriteLong( finalGive );
                 msg.End();
             }
 


### PR DESCRIPTION
## Description
Change WriteByte to WriteLong for the ammo amount in BTS_Ammo::PickupObject. This aligns the user message size with Sven Co-op's expectation of 5 bytes (1-byte index + 4-byte amount) and prevents the "WARNING: MessageEnd: User Msg 'AmmoPickup': 2 bytes written, expected 5" warning.

## Related Issues
Links to any issues resolved or related:
- Closes #43
- Fixes #43

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization / Refactor (improving codebase efficiency or structure)
- [ ] Documentation update (improving guides, wiki, or comments)

## Verification Performed
Describe the manual/automated testing conducted to verify your changes:
1. Steps taken to test: Created `ammo_bts_flashlight` and picked it up.
2. Server/client console logs: Verified that the warning message `WARNING: MessageEnd: User Msg 'AmmoPickup': 2 bytes written, expected 5` is no longer printed to the console upon pickup.

## Checklist
- [x] My code follows the code style guidelines of this project (Allman braces, spacing inside parentheses).
- [x] I have run `python src/apply_license.py` to ensure all script files have proper license headers.
- [x] I have verified that compiling the scripts does not trigger any warnings or errors using both `SERVER` and `DEBUG` preprocessors with `src/toggle_debug.py`
- [ ] I have updated the documentation / website (`docs/`) if my changes introduce or modify configurable keys.