### PR TITLE
Fix standalone flashlight lifecycle and M4 animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # 14/07/2026
+## Scripts
+- Fixed the standalone flashlight remaining active after switching or dropping it and prevented interrupted battery reloads from granting a full charge.
+- Corrected M4 and suppressed M4 animation sequences for fire-mode changes, reloads, draws, firing, and idles.
+
 ## Pages
 - Fixed and improved the changelog section.
 

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/weapon_bts_m4.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/weapon_bts_m4.as
@@ -96,13 +96,13 @@ ASWeaponM4Config gpWeaponM4Config;
 enum WeaponM4Anim
 {
     LONGIDLE = 0,
-    IDLE1,
-    SEMIE,
-    RELOAD,
-    DRAW,
-    SHOOT1,
-    SHOOT2,
-    SHOOT3
+    IDLE1 = 1,
+    FIREMODE = 2,
+    RELOAD = 3,
+    DRAW = 4,
+    SHOOT1 = 5,
+    SHOOT2 = 6,
+    SHOOT3 = 7
 };
 
 enum M4Mode
@@ -143,7 +143,7 @@ class weapon_bts_m4 : BTS_FireWeapon
                 g_EngineFuncs.ClientPrintf( player, print_center, " Semi\n" );
                 PlaySound( "bts_rc/weapons/grenade_pinpull.wav", 0.8f, 115 );
             }
-            PlayAnim( WeaponM4Anim::LONGIDLE );
+            PlayAnim( WeaponM4Anim::FIREMODE );
             self.m_flTimeWeaponIdle = g_Engine.time + Math.RandomFloat( 5.0f, 10.0f );
             self.m_flNextPrimaryAttack = self.m_flNextSecondaryAttack = g_Engine.time + 0.5f;
             return;

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/weapon_bts_m4sd.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/weapon_bts_m4sd.as
@@ -96,12 +96,13 @@ ASWeaponM4SDConfig gpWeaponM4SDConfig;
 enum WeaponM4SDAnim
 {
     LONGIDLE = 0,
-    IDLE1,
-    RELOAD,
-    DRAW,
-    SHOOT1,
-    SHOOT2,
-    SHOOT3
+    IDLE1 = 1,
+    FIREMODE = 2,
+    RELOAD = 3,
+    DRAW = 4,
+    SHOOT1 = 5,
+    SHOOT2 = 6,
+    SHOOT3 = 7
 };
 
 enum M4SDMode
@@ -142,7 +143,7 @@ class weapon_bts_m4sd : BTS_FireWeapon
                 g_EngineFuncs.ClientPrintf( player, print_center, " Semi\n" );
                 PlaySound( "bts_rc/weapons/grenade_pinpull.wav", 0.8f, 115 );
             }
-            PlayAnim( WeaponM4SDAnim::LONGIDLE );
+            PlayAnim( WeaponM4SDAnim::FIREMODE );
             self.m_flTimeWeaponIdle = g_Engine.time + Math.RandomFloat( 5.0f, 10.0f );
             self.m_flNextPrimaryAttack = self.m_flNextSecondaryAttack = g_Engine.time + 0.5f;
             return;
@@ -232,7 +233,7 @@ class weapon_bts_m4sd : BTS_FireWeapon
                 break;
             case 1:
             default:
-                PlayAnim( WeaponM4Anim::IDLE1 );
+                PlayAnim( WeaponM4SDAnim::IDLE1 );
                 break;
         }
 

--- a/scripts/maps/bts_rc/entities/weapons/Special/weapon_bts_flashlight.as
+++ b/scripts/maps/bts_rc/entities/weapons/Special/weapon_bts_flashlight.as
@@ -78,12 +78,6 @@ final class ASWeaponFlashlightConfig : ASMeleeWeaponConfig
         return WeaponFlashlightAnim::Draw;
     }
 
-    void WeaponHolster( CBasePlayer@ player, CBasePlayerWeapon@ weapon, CCharacter@ character ) override
-    {
-        Flashlight::Holster( player, weapon, character );
-        ASMeleeWeaponConfig::WeaponHolster( player, weapon, character );
-    }
-
     void PlayerThink( CBasePlayer@ player, CBasePlayerWeapon@ weapon, CCharacter@ character ) override
     {
         Flashlight::Think( player, weapon, character, this, this.flashlight_model );
@@ -158,6 +152,12 @@ final class weapon_bts_flashlight : BTS_MeleeWeapon
     {
         self.m_iDefaultAmmo = Math.RandomLong( 0, 2 );
         BTS_MeleeWeapon::Spawn();
+    }
+
+    void Holster( int skiplocal = 0 ) override
+    {
+        Flashlight::Holster( this.owner, self, null );
+        BTS_MeleeWeapon::Holster( skiplocal );
     }
 
     float Idle() override

--- a/scripts/maps/bts_rc/entities/weapons/config/Flashlight.as
+++ b/scripts/maps/bts_rc/entities/weapons/config/Flashlight.as
@@ -54,7 +54,6 @@ namespace Flashlight
             g_SoundSystem.StopSound( player.edict(), CHAN_WEAPON, "bts_rc/items/battery_reload.wav" );
 
             dictionary@ data = player.GetUserData();
-            data[ weapon.GetClassname() ] = flashlight_ammount;
             weapon.m_fInReload = false;
             data.delete( "flashlight_reload" );
         }

--- a/scripts/maps/bts_rc/entities/weapons/default_config.json
+++ b/scripts/maps/bts_rc/entities/weapons/default_config.json
@@ -271,8 +271,8 @@
         "primary_dropammo": 30,
         "primary_maxammo": 150,
         "primary_trained_cooldown": 0.105,
-        "reload_anim": 2,
-        "reload_empty_anim": 2,
+        "reload_anim": 3,
+        "reload_empty_anim": 3,
         "reload_sound": "bts_rc/weapons/fidget_3.wav",
         "slot": 2,
         "weight": 5

--- a/scripts/maps/bts_rc/util/utils.as
+++ b/scripts/maps/bts_rc/util/utils.as
@@ -25,7 +25,7 @@
 
 #include "../../../mikk155/SemanticVersion"
 
-const SemanticVersion@ g_ScriptsVersion = SemVer( 4, 1, 1 );
+const SemanticVersion@ g_ScriptsVersion = SemVer( 4, 1, 2 );
 
 // Whatever the current map is bts_rc
 const bool g_IsMainMap = ( string( g_Engine.mapname ) == "bts_rc" );


### PR DESCRIPTION
## Description

Fix the standalone flashlight remaining active after switching weapons or dropping it. Flashlight cleanup now runs through the weapon's actual holster lifecycle, matching the working behavior of flashlight-bearing weapons.

Interrupted flashlight battery reloads also preserve the existing charge instead of granting a full battery.

Correct the M4 and suppressed M4 animation mappings against their model sequence tables. Fire-mode, reload, deploy, firing, and idle animations now use the appropriate sequence IDs.

Update the changelog and bump `g_ScriptsVersion` from `4.1.1` to `4.1.2`.

## Related Issues

- Fixes #59

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization / Refactor (improving codebase efficiency or structure)
- [ ] Documentation update (improving guides, wiki, or comments)

## Verification Performed

1. Ran `python src/main.py --check`; all registered checks passed.
2. Compared the M4 and M4SD mappings against the installed `v_m4.mdl` and `v_m4sd.mdl` sequence tables.
3. In-game verification of flashlight switching/dropping and weapon animations is still pending.

## Checklist

- [x] My code follows the project code-style guidelines.
- [x] I have run `python src/main.py --check` to validate the script files.
- [x] I have updated `CHANGELOG.md`.
- [ ] I have checked `svencoop/scripts/maps/store/bts_rc.log` for `Critical` or `Error` entries.
- [x] I have updated `g_ScriptsVersion` according to Semantic Versioning.