### PR TITLE
Fix correct idle animation timing

### DIFF
--- a/scripts/maps/bts_rc/entities/weapons/base/BTS_Weapon.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/BTS_Weapon.as
@@ -80,7 +80,7 @@ abstract class BTS_Weapon : ScriptBasePlayerWeaponEntity
     {
         if( self.m_flTimeWeaponIdle < g_Engine.time )
         {
-            self.m_flTimeWeaponIdle = Idle();
+            self.m_flTimeWeaponIdle = g_Engine.time + Idle();
         }
     }
 


### PR DESCRIPTION
## Description

Schedule weapon idle timers relative to the current engine time.

Previously, `WeaponIdle()` stored the relative duration returned by `Idle()` as an absolute timestamp. After the map time exceeded that value, idle animations restarted every frame. Holding an unsupported secondary/tertiary attack or attempting to reload a full weapon temporarily skipped the idle handler, making the sequence appear to play only while the button was held.

## Related Issues

No related issue.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization / Refactor (improving codebase efficiency or structure)
- [ ] Documentation update (improving guides, wiki, or comments)

## Verification Performed

1. Ran `python src/main.py --check`; all registered checks passed.
2. Performed in-game verification.
3. Confirmed unsupported secondary/tertiary attacks and full-clip reload attempts no longer cause the idle sequence behavior.

## Checklist

- [x] My code follows the code style guidelines of this project (Allman braces, spacing inside parentheses).
- [x] I have run `python src/main.py` to ensure all script files have been validated.
- [ ] I have updated `CHANGELOG.md` according to our [rules](https://github.com/Mikk155/bts_rc/wiki/changelog).
- [ ] I have checked `svencoop/scripts/maps/store/bts_rc.log` to see there is not any logger entry with `Critical` or `Error` level.
- [ ] I have updated `g_ScriptsVersion` at `scripts/maps/bts_rc/util/utils.as` according to [Semantic versioning](https://semver.org/).