### PR TITLE
fix(weapons): restore axe secondary hit range

### DIFF
--- a/scripts/maps/bts_rc/entities/weapons/default_config.json
+++ b/scripts/maps/bts_rc/entities/weapons/default_config.json
@@ -10,6 +10,7 @@
         "primary_trained_cooldown": 0.4,
         "secondary_cooldown": 0.5,
         "secondary_damage": 14,
+        "secondary_distance": 45,
         "secondary_miss_cooldown": 1.35,
         "secondary_miss_trained_cooldown": 1.0,
         "secondary_trained_cooldown": 0.25,


### PR DESCRIPTION
## Description
Added the missing secondary_distance value to the axe’s default configuration. Without it, the alternate-fire trace had zero range, so only the animation played and the existing damage and shove logic never reached a target.

## Related Issues
Links to any issues resolved or related:
- Closes #75 
- Fixes #75 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization / Refactor (improving codebase efficiency or structure)
- [ ] Documentation update (improving guides, wiki, or comments)

## Verification Performed
Describe the manual/automated testing conducted to verify your changes:
1. Steps taken to test (e.g. "Started map `bts_rc_test_chamber`, collected `GEAR_1`, and checked if MOTD reflected change").
2. Server/client console logs (if applicable).

## Checklist
- [x] My code follows the code style guidelines of this project (Allman braces, spacing inside parentheses).
- [x] I have run `python src/main.py` to ensure all script files have been validated.
- [ ] I have updated ``CHANGELOG.md`` according to our [rules](https://github.com/Mikk155/bts_rc/wiki/changelog)
- [ ] I have checked ``svencoop/scripts/maps/store/bts_rc.log`` to see there is not any logger entry with ``Critical`` or ``Error`` level.
- [ ] I have updated ``g_ScriptsVersion`` at ``scripts/maps/bts_rc/util/utils.as`` according to [Semantic versioning](https://semver.org/)
