### PR TITLE
fix(weapons): correct flamethrower inventory slot

### DIFF
--- a/scripts/maps/bts_rc/entities/weapons/default_config.json
+++ b/scripts/maps/bts_rc/entities/weapons/default_config.json
@@ -76,7 +76,7 @@
         "primary_dropammo": 40,
         "primary_maxammo": 120,
         "primary_trained_cooldown": 0.1,
-        "slot": 5,
+        "slot": 3,
         "weight": 30
     },
     "weapon_bts_flare": {


### PR DESCRIPTION
## Description
Changed the flamethrower’s inventory slot from 5 to 3, restoring its original slot assignment. The sniper rifle remains in slot 5, so the two weapons no longer share the same slot and position combination.

## Related Issues
Links to any issues resolved or related:
- Closes #76 
- Fixes #76 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Optimization / Refactor (improving codebase efficiency or structure)
- [ ] Documentation update (improving guides, wiki, or comments)

## Verification Performed
Ran python src/main.py --check.
All automated validation checks passed, including schema and weapon-default checks.
Confirmed the resulting assignments:Flamethrower: slot 3, position 5
Sniper rifle: slot 5, position 5
In-game testing and server/client log inspection were performed.

## Checklist
- [x] My code follows the code style guidelines of this project (Allman braces, spacing inside parentheses).
- [x] I have run `python src/main.py` to ensure all script files have been validated.
- [ ] I have updated ``CHANGELOG.md`` according to our [rules](https://github.com/Mikk155/bts_rc/wiki/changelog)
- [ ] I have checked ``svencoop/scripts/maps/store/bts_rc.log`` to see there is not any logger entry with ``Critical`` or ``Error`` level.
- [ ] I have updated ``g_ScriptsVersion`` at ``scripts/maps/bts_rc/util/utils.as`` according to [Semantic versioning](https://semver.org/)
