### PR TITLE
Pattern builder-like prototype to fire bullets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,8 @@
     {
         // We allow comments in AngelScript json
         "*.json": "jsonc",
-        "*.as": "angelscript"
+        "*.as": "angelscript",
+        "*.predefined": "angelscript"
     },
 
     // Sven co-op specifics

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,7 +18,6 @@
 - [Gaftherman](https://github.com/Gaftherman)
 - Gamit
 - Gauna
-- Gearbox
 - Gearbox Software
 - Generic
 - [Giegue](https://github.com/julianR0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 10/8/2026
+## Scripts
+- Weapons now displays lighting on firing.
+- Weapons now displays trace effects on firing (Visible in first person now).
+- Weapons now displays bubble trails under water.
+- Weapons now has proper accumulative kick back.
+- Swapped some effects map-wide broadcasts (`MSG_BROADCAST`) to Potentially Visible Set broadcasts (`MSG_PVS`).
+- Added an admin command ``bts_rc weapon infinite_ammo`` to global toggle infinite ammo of weapons and flashlight.
+
 # 9/8/2026
 ## Scripts
 - Replaced fire arms shooting structure to be more flexible and maintainable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 9/8/2026
+## Scripts
+- Replaced fire arms shooting structure to be more flexible and maintainable.
+- Exposed multiple weapon variables to json.
+
 # 27/7/2026
 ## Scripts
 ### Flashlight System Overhaul & Refinement

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This file contains the list of to-do in the project.
 <!-- Python will insert the completion bar by finding the next comments.-->
 ## Completion Progress
 <!--CompletionBar-start-->
-> ![](https://geps.dev/progress/24.358974358974358?barColor=da700b)
+> ![](https://geps.dev/progress/24.050632911392405?barColor=da6e0b)
 <!--CompletionBar-end-->
 
 ---
@@ -26,6 +26,7 @@ This file contains the list of to-do in the project.
 > - Run ``src/main.py`` to generate roadmap graph and organize completion of goals.
 ---
 
+- [ ] Reimplement the whole hev fvox updates for hev characters (Update ASBullet::DeduceAmmo).
 - [ ] Add "active" checks to all loggers that may not have it.
 - [ ] Implement ASBullet to all fire arms.
 - [ ] Fix loggers with only one item in the array formating the message with an additional ``}`` not removed from the message.

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This file contains the list of to-do in the project.
 <!-- Python will insert the completion bar by finding the next comments.-->
 ## Completion Progress
 <!--CompletionBar-start-->
-> ![](https://geps.dev/progress/27.941176470588236?barColor=da7e0b)
+> ![](https://geps.dev/progress/26.76056338028169?barColor=da7a0b)
 <!--CompletionBar-end-->
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This file contains the list of to-do in the project.
 <!-- Python will insert the completion bar by finding the next comments.-->
 ## Completion Progress
 <!--CompletionBar-start-->
-> ![](https://geps.dev/progress/26.76056338028169?barColor=da7a0b)
+> ![](https://geps.dev/progress/25.333333333333336?barColor=da740b)
 <!--CompletionBar-end-->
 
 ---
@@ -26,6 +26,10 @@ This file contains the list of to-do in the project.
 > - Run ``src/main.py`` to generate roadmap graph and organize completion of goals.
 ---
 
+- [ ] Replace ASBullet's g_Engine.trace_* to g_Utility's GetGlobalTrace.
+- [ ] RegisterCommand rename class to ASCommand and create a method for RegisterCommand.
+- [ ] CommandContext should print help for specific commands in the argument 1 if it's a section i.e "bts_rc weapon" should print all commands in the weapon section.
+- [ ] Maybe reuse weapon melee distance configs into ASBullet
 - [ ] weapon json variable int[2] for default ammo min/max on spawn (clip ammo check)
 - [ ] weapon json variable int[2] for default secondary ammo min/max on spawn
 - [ ] replace all FireBullet( & FireBullets( to ASBullet pattern

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@ This file contains the list of to-do in the project.
 <!-- Python will insert the completion bar by finding the next comments.-->
 ## Completion Progress
 <!--CompletionBar-start-->
-> ![](https://geps.dev/progress/25.333333333333336?barColor=da740b)
+> ![](https://geps.dev/progress/24.358974358974358?barColor=da700b)
 <!--CompletionBar-end-->
 
 ---
@@ -26,6 +26,9 @@ This file contains the list of to-do in the project.
 > - Run ``src/main.py`` to generate roadmap graph and organize completion of goals.
 ---
 
+- [ ] Add "active" checks to all loggers that may not have it.
+- [ ] Implement ASBullet to all fire arms.
+- [ ] Fix loggers with only one item in the array formating the message with an additional ``}`` not removed from the message.
 - [ ] Replace ASBullet's g_Engine.trace_* to g_Utility's GetGlobalTrace.
 - [ ] RegisterCommand rename class to ASCommand and create a method for RegisterCommand.
 - [ ] CommandContext should print help for specific commands in the argument 1 if it's a section i.e "bts_rc weapon" should print all commands in the weapon section.

--- a/scripts/maps/bts_rc/default_config.json
+++ b/scripts/maps/bts_rc/default_config.json
@@ -1,6 +1,5 @@
 {
     "$schema": "schema.json",
-
     "aiming_lasers": {
         "active": true,
         "alpha": 150,
@@ -380,13 +379,13 @@
             "stand": 0.03,
             "stand_trained": 0.006
         },
+        "primary_cooldown": 0.1,
+        "primary_damage": 15,
+        "primary_dropammo": 15,
         "primary_kickback": {
             "stand": 2.5,
             "stand_trained": 2.0
         },
-        "primary_cooldown": 0.1,
-        "primary_damage": 15,
-        "primary_dropammo": 15,
         "primary_maxammo": 120,
         "primary_trained_cooldown": 0.05,
         "reload_anim": 6,
@@ -425,13 +424,13 @@
             "stand": 0.05,
             "stand_trained": 0.01
         },
+        "primary_cooldown": 0.22,
+        "primary_damage": 65,
+        "primary_dropammo": 3,
         "primary_kickback": {
             "stand": 11.0,
             "stand_trained": 4.0
         },
-        "primary_cooldown": 0.22,
-        "primary_damage": 65,
-        "primary_dropammo": 3,
         "primary_maxammo": 18,
         "primary_trained_cooldown": 0.22,
         "reload_anim": 8,
@@ -1005,6 +1004,7 @@
     "weapons": {
         "blood_splash": true,
         "flashlight_maxcarry": 10,
+        "infinite_ammo": false,
         "item_remap": {
             "weapon_sniperrifle": "weapon_bts_sniperrifle"
         },

--- a/scripts/maps/bts_rc/default_config.json
+++ b/scripts/maps/bts_rc/default_config.json
@@ -1,6 +1,6 @@
 {
     "$schema": "schema.json",
-    
+
     "aiming_lasers": {
         "active": true,
         "alpha": 150,
@@ -424,6 +424,10 @@
             "crouch_trained": 0.009,
             "stand": 0.05,
             "stand_trained": 0.01
+        },
+        "primary_kickback": {
+            "stand": 11.0,
+            "stand_trained": 4.0
         },
         "primary_cooldown": 0.22,
         "primary_damage": 65,

--- a/scripts/maps/bts_rc/default_config.json
+++ b/scripts/maps/bts_rc/default_config.json
@@ -379,6 +379,10 @@
             "stand": 0.03,
             "stand_trained": 0.006
         },
+        "primary_kickback": {
+            "stand": 2.5,
+            "stand_trained": 2.0
+        },
         "primary_cooldown": 0.1,
         "primary_damage": 15,
         "primary_dropammo": 15,

--- a/scripts/maps/bts_rc/entities/monsters/lasers.as
+++ b/scripts/maps/bts_rc/entities/monsters/lasers.as
@@ -207,7 +207,7 @@ final class ASAimingLasersConfig : EntityOverriden, IConfigurable
 
         if( classname == "monster_turret" )
         {
-            NetworkMessage m( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+            NetworkMessage m( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
                 m.WriteByte( TE_DLIGHT );
                 m.WriteCoord( VecStart.x );
                 m.WriteCoord( VecStart.y );
@@ -221,7 +221,7 @@ final class ASAimingLasersConfig : EntityOverriden, IConfigurable
             m.End();
         }
         {
-            NetworkMessage m( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+            NetworkMessage m( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
                 m.WriteByte( TE_DLIGHT );
                 m.WriteCoord( tr.vecEndPos.x );
                 m.WriteCoord( tr.vecEndPos.y );
@@ -235,7 +235,7 @@ final class ASAimingLasersConfig : EntityOverriden, IConfigurable
             m.End();
         }
         {
-            NetworkMessage m( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+            NetworkMessage m( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
                 m.WriteByte( TE_BEAMPOINTS );
                 m.WriteCoord( VecStart.x );
                 m.WriteCoord( VecStart.y );

--- a/scripts/maps/bts_rc/entities/monsters/monster_zombie_parasite.as
+++ b/scripts/maps/bts_rc/entities/monsters/monster_zombie_parasite.as
@@ -43,11 +43,11 @@ enum HeadcrabRelease_t
 {
     RELEASE_NO = 0,
     RELEASE_IMMEDIATE,  // release the headcrab right now!
-    RELEASE_VAPORIZE,       // just destroy the crab.   
+    RELEASE_VAPORIZE,       // just destroy the crab.
     RELEASE_RAGDOLL     // release a dead crab
 };
 
-const array<string> arrsSounds = 
+const array<string> arrsSounds =
 {
     "zombie/claw_strike1.wav",
     "zombie/claw_strike2.wav",
@@ -164,7 +164,7 @@ final class monster_zombie_parasite : bts_rc_base_monster
             iIgnore |= bits_COND_SEE_FEAR | bits_COND_LIGHT_DAMAGE | bits_COND_HEAVY_DAMAGE;
 
         return iIgnore;
-        
+
     }
 
     int BaseIgnoreConditions()
@@ -381,7 +381,7 @@ final class monster_zombie_parasite : bts_rc_base_monster
         return tookDamage;
     }
 
-    void TraceAttack( entvars_t@ pevAttacker, float flDamage, const Vector &in vecDir, TraceResult &in ptr, int bitsDamageType ) 
+    void TraceAttack( entvars_t@ pevAttacker, float flDamage, const Vector &in vecDir, TraceResult &in ptr, int bitsDamageType )
     {
         if( ptr.iHitgroup == HITGROUP_HEAD )
             m_bHeadShot = true;
@@ -456,9 +456,9 @@ final class monster_zombie_parasite : bts_rc_base_monster
             {
                 Vector vecSpot2 = cbeCrab.pev.origin;
 
-                vecSpot2.x += Math.RandomFloat( -8.0, 8.0 ); 
-                vecSpot2.y += Math.RandomFloat( -8.0, 8.0 ); 
-                vecSpot2.z += Math.RandomFloat( -8.0, 8.0 ); 
+                vecSpot2.x += Math.RandomFloat( -8.0, 8.0 );
+                vecSpot2.y += Math.RandomFloat( -8.0, 8.0 );
+                vecSpot2.z += Math.RandomFloat( -8.0, 8.0 );
 
                 g_Utility.BloodDrips( vecSpot, g_vecZero, BLOOD_COLOR_YELLOW, 50 );
             }
@@ -480,11 +480,11 @@ final class monster_zombie_parasite : bts_rc_base_monster
 
             // don't pop to floor, fall
             //cbeCrab->AddSpawnFlags( SF_NPC_FALL_TO_GROUND );
-            
+
             // add on the parent flags
             //cbeCrab->AddSpawnFlags( m_spawnflags & ZOMBIE_CRAB_INHERITED_SPAWNFLAGS );
             cbeCrab.pev.spawnflags |= ( pev.spawnflags & 2 ); //SF_MONSTER_GAG
-            
+
             g_EntityFuncs.SetOrigin( cbeCrab, vecSpot );
             g_EntityFuncs.DispatchSpawn( cbeCrab.edict() );
 
@@ -544,7 +544,7 @@ final class monster_zombie_parasite : bts_rc_base_monster
 
         TraceResult tr;
         //g_Utility.TraceHull( vecSpawnLoc, vecSpawnLoc - Vector(0, 0, 1), dont_ignore_monsters, head_hull, self.edict(), tr );
-        g_Utility.TraceMonsterHull( pCrab.edict(), vecSpawnLoc, vecSpawnLoc + Vector(0, 0, 1), dont_ignore_monsters, self.edict(), tr ); 
+        g_Utility.TraceMonsterHull( pCrab.edict(), vecSpawnLoc, vecSpawnLoc + Vector(0, 0, 1), dont_ignore_monsters, self.edict(), tr );
 
         if( tr.flFraction != 1.0 )
             return false;
@@ -598,16 +598,16 @@ final class CParasiteZombieCloud : ScriptBaseEntity
     {
         g_EntityFuncs.SetSize( self.pev, g_vecZero, g_vecZero );
 
-        NetworkMessage m1( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+        NetworkMessage m1( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
             m1.WriteByte( TE_FIREFIELD );
             m1.WriteCoord( pev.origin.x );
             m1.WriteCoord( pev.origin.y );
             m1.WriteCoord( pev.origin.z );
-            m1.WriteShort( m_iPoisonCloudRadius ); //radius (fire is made in a square around origin. -radius, -radius to radius, radius) 
+            m1.WriteShort( m_iPoisonCloudRadius ); //radius (fire is made in a square around origin. -radius, -radius to radius, radius)
             m1.WriteShort( g_EngineFuncs.ModelIndex("sprites/poison.spr") );
             m1.WriteByte( m_iPoisonCloudCount ); //count
             m1.WriteByte( TEFIRE_FLAG_ALLFLOAT | TEFIRE_FLAG_ADDITIVE );
-            m1.WriteByte( m_iPoisonCloudDuration ); //duration (in seconds) * 10 (will be randomized a bit) 
+            m1.WriteByte( m_iPoisonCloudDuration ); //duration (in seconds) * 10 (will be randomized a bit)
         m1.End();
 
         m_flRemoveTime = g_Engine.time + POISON_DURATION;
@@ -624,7 +624,7 @@ final class CParasiteZombieCloud : ScriptBaseEntity
             return;
         }
 
-        if( m_flPoisonDamage > 0 ) 
+        if( m_flPoisonDamage > 0 )
         {
             m_flPoisonDamage -= 0.5;
             g_WeaponFuncs.RadiusDamage( pev.origin, self.pev, self.pev, m_flPoisonDamage, POISON_DAMAGE_RADIUS, CLASS_MACHINE, DMG_POISON | DMG_NEVERGIB );

--- a/scripts/maps/bts_rc/entities/monsters/robogrunt.as
+++ b/scripts/maps/bts_rc/entities/monsters/robogrunt.as
@@ -207,7 +207,7 @@ class ASRoboGrunt : EntityOverriden, IConfigurable
 
                 if( FreeEdicts( 1 ) )
                 {
-                    NetworkMessage m1( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY, vecOrigin );
+                    NetworkMessage m1( MSG_PVS, NetworkMessages::SVC_TEMPENTITY, vecOrigin );
                         m1.WriteByte( TE_SMOKE );
                         m1.WriteCoord( vecOrigin.x );
                         m1.WriteCoord( vecOrigin.y );

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/beretta.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/beretta.as
@@ -129,40 +129,14 @@ class weapon_bts_beretta : BTS_FireWeapon
         return Math.RandomFloat( 6.0f, 8.0f );
     }
 
-    void Attack( CBasePlayer@ player, AttackType type ) override
+    void PrimaryAttack() override
     {
-        switch( type )
+        CBasePlayer@ player = this.owner;
+
+        if( ( player.m_afButtonPressed & IN_ATTACK ) != 0 )
         {
-            case AttackType::Tertiary:
-            case AttackType::Secondary:
-                return;
+            bullet.Sound( "bts_rc/weapons/beretta_fire1.wav", Math.RandomFloat( 0.92f, 1.0f ) )
+                .Fire( player, this, AttackType::Primary, gpWeaponBerettaConfig );
         }
-
-        if( self.m_iClip <= 0 )
-        {
-            this.PlayEmptySound();
-            self.m_flNextPrimaryAttack = g_Engine.time + 0.2f;
-            return;
-        }
-
-        if( ( player.m_afButtonPressed & IN_ATTACK ) == 0 )
-        {
-            return;
-        }
-
-        bool isTrainedPersonal = util::IsTrainedPersonal( player );
-
-        float cone = weapons::Accuracy( player, gpWeaponBerettaConfig.primary_accuracy, isTrainedPersonal );
-
-        uint8 anim = self.m_iClip > 1 ? WeaponBerettaAnim::Shoot : WeaponBerettaAnim::ShootEmpty;
-
-        FireBullet( 1, cone, gpWeaponBerettaConfig.primary_damage, "bts_rc/weapons/beretta_fire1.wav", anim, models::shell, TE_BOUNCE_SHELL, Math.RandomFloat( 0.92f, 1.0f ) );
-
-        player.pev.punchangle.x = isTrainedPersonal ? -2.0f : -2.5f;
-
-        self.m_flNextSecondaryAttack = self.m_flNextTertiaryAttack = g_Engine.time + 0.3f;
-        self.m_flNextPrimaryAttack = g_Engine.time + ( isTrainedPersonal ? 0.05f : 0.10f );
-        self.m_flTimeWeaponIdle = g_Engine.time + Math.RandomFloat( 10.0f, 15.0f );
     }
-
 }

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/beretta.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/beretta.as
@@ -135,10 +135,12 @@ class weapon_bts_beretta : BTS_FireWeapon
 
         if( ( player.m_afButtonPressed & IN_ATTACK ) != 0 )
         {
-            uint8 anim = self.m_iClip > 1 ? WeaponBerettaAnim::Shoot : WeaponBerettaAnim::ShootEmpty;
-
-            bullet.Sound( "bts_rc/weapons/beretta_fire1.wav", Math.RandomFloat( 0.92f, 1.0f ) )
-                .Fire( player, this, AttackType::Primary, gpWeaponBerettaConfig, anim );
+            bullet.Weapon( this )
+                .Sound( "bts_rc/weapons/beretta_fire1.wav" )
+                .Volume( Math.RandomFloat( 0.92f, 1.0f ) )
+                .Flash( DIM_GUN_FLASH )
+                .Animation( self.m_iClip > 1 ? WeaponBerettaAnim::Shoot : WeaponBerettaAnim::ShootEmpty )
+            .Fire();
         }
     }
 }

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/beretta.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/beretta.as
@@ -135,8 +135,10 @@ class weapon_bts_beretta : BTS_FireWeapon
 
         if( ( player.m_afButtonPressed & IN_ATTACK ) != 0 )
         {
+            uint8 anim = self.m_iClip > 1 ? WeaponBerettaAnim::Shoot : WeaponBerettaAnim::ShootEmpty;
+
             bullet.Sound( "bts_rc/weapons/beretta_fire1.wav", Math.RandomFloat( 0.92f, 1.0f ) )
-                .Fire( player, this, AttackType::Primary, gpWeaponBerettaConfig );
+                .Fire( player, this, AttackType::Primary, gpWeaponBerettaConfig, anim );
         }
     }
 }

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/eagle.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/eagle.as
@@ -153,38 +153,16 @@ class weapon_bts_eagle : BTS_FireWeapon
         }
     }
 
-    void Attack( CBasePlayer@ player, AttackType type ) override
+    void SecondaryAttack() override
     {
-        bool isTrainedPersonal = util::IsTrainedPersonal( player );
+        auto player = this.owner;
+        gpWeaponEagleConfig.LaserToggle( util::IsTrainedPersonal( player ), AttackType::Secondary, self, player );
+    }
 
-        switch( type )
-        {
-            case AttackType::Secondary:
-            {
-                gpWeaponEagleConfig.LaserToggle( isTrainedPersonal, type, self, this.owner );
-                break;
-            }
-            case AttackType::Primary:
-            {
-                if( self.m_iClip <= 0 )
-                {
-                    this.PlayEmptySound();
-                    self.m_flNextPrimaryAttack = g_Engine.time + 0.2f;
-                    return;
-                }
-
-                float cone = weapons::Accuracy( player, gpWeaponEagleConfig.primary_accuracy, isTrainedPersonal );
-
-                uint8 anim = self.m_iClip > 1 ? WeaponEagleAnim::Shoot : WeaponEagleAnim::ShootEmpty;
-
-                FireBullet( 1, cone, gpWeaponEagleConfig.primary_damage, "weapons/desert_eagle_fire.wav", anim, models::shell, TE_BOUNCE_SHELL, Math.RandomFloat( 0.92f, 1.0f ) );
-
-                player.pev.punchangle.x = isTrainedPersonal ? -4.0f : -11.0f;
-
-                gpWeaponEagleConfig.SetCooldown( isTrainedPersonal, type, self, this.owner );
-
-                break;
-            }
-        }
+    void PrimaryAttack() override
+    {
+        uint8 anim = self.m_iClip > 1 ? WeaponEagleAnim::Shoot : WeaponEagleAnim::ShootEmpty;
+        bullet.Sound( "weapons/desert_eagle_fire.wav", Math.RandomFloat( 0.92f, 1.0f ) )
+            .Fire( this.owner, this, AttackType::Primary, gpWeaponEagleConfig, anim );
     }
 }

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/eagle.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/eagle.as
@@ -161,8 +161,10 @@ class weapon_bts_eagle : BTS_FireWeapon
 
     void PrimaryAttack() override
     {
-        uint8 anim = self.m_iClip > 1 ? WeaponEagleAnim::Shoot : WeaponEagleAnim::ShootEmpty;
-        bullet.Sound( "weapons/desert_eagle_fire.wav", Math.RandomFloat( 0.92f, 1.0f ) )
-            .Fire( this.owner, this, AttackType::Primary, gpWeaponEagleConfig, anim );
+        bullet.Weapon( this )
+            .Sound( "weapons/desert_eagle_fire.wav" )
+            .Volume( Math.RandomFloat( 0.92f, 1.0f ) )
+            .Animation( self.m_iClip > 1 ? WeaponEagleAnim::Shoot : WeaponEagleAnim::ShootEmpty )
+        .Fire();
     }
 }

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/flaregun.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/flaregun.as
@@ -85,7 +85,6 @@ class weapon_bts_flaregun : BTS_FireWeapon
         BTS_FireWeapon::Spawn();
     }
 
-
     void Attack( CBasePlayer@ player, AttackType type ) override
     {
         switch( type )
@@ -135,7 +134,7 @@ class weapon_bts_flaregun : BTS_FireWeapon
         self.m_flTimeWeaponIdle = g_Engine.time + 5.0f;
     }
 
-    
+
 
     float Idle() override
     {

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/saw.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/saw.as
@@ -160,7 +160,7 @@ class weapon_bts_saw : BTS_FireWeapon
         TraceResult tr;
         g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
         self.FireBullets( 1, vecSrc, vecDir, g_vecZero, 8192.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int(gpWeaponSawConfig.primary_damage), player.pev );
-        TraceEffects( tr, Bullet::BULLET_PLAYER_CUSTOMDAMAGE );
+        TraceEffects(tr);
 
         if( ( m_iTracerCount++ % 2 ) == 0 )
         {

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/sawsd.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/sawsd.as
@@ -157,7 +157,7 @@ class weapon_bts_sawsd : BTS_FireWeapon
         TraceResult tr;
         g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
         self.FireBullets( 1, vecSrc, vecDir, g_vecZero, 8192.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int(gpWeaponSawSDConfig.primary_damage), player.pev );
-        TraceEffects( tr, Bullet::BULLET_PLAYER_CUSTOMDAMAGE );
+        TraceEffects(tr);
 
         if( ( m_iTracerCount++ % 2 ) == 0 )
         {
@@ -199,7 +199,7 @@ class weapon_bts_sawsd : BTS_FireWeapon
         }
     }
 
-    
+
 
     private void RecalculateBody( int iClip )
     {

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/sbshotgun.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/sbshotgun.as
@@ -186,7 +186,7 @@ class weapon_bts_sbshotgun : BTS_FireWeapon
 
             g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
             self.FireBullets( 1, vecSrc, vecDir, g_vecZero, 2048.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int( damage ), player.pev );
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CUSTOMDAMAGE );
+            TraceEffects(tr);
         }
 
         bool isTrainedPersonal = util::IsTrainedPersonal( player );

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/shotgun.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/shotgun.as
@@ -162,7 +162,7 @@ class weapon_bts_shotgun : BTS_FireWeapon
 
                 g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
                 self.FireBullets( 1, vecSrc, vecDir, g_vecZero, 2048.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int( damage ), player.pev );
-                TraceEffects( tr, Bullet::BULLET_PLAYER_CUSTOMDAMAGE );
+                TraceEffects(tr);
             }
 
             bool isTrainedPersonal = util::IsTrainedPersonal( player );
@@ -245,7 +245,7 @@ class weapon_bts_shotgun : BTS_FireWeapon
 
             g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
             self.FireBullets( 1, vecSrc, vecDir, g_vecZero, 2048.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int( damage ), player.pev );
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CUSTOMDAMAGE );
+            TraceEffects(tr);
         }
 
         bool isTrainedPersonal = util::IsTrainedPersonal( player );

--- a/scripts/maps/bts_rc/entities/weapons/Firearms/xbow.as
+++ b/scripts/maps/bts_rc/entities/weapons/Firearms/xbow.as
@@ -125,7 +125,7 @@ class electro_bolt : ScriptBaseEntity
         g_EntityFuncs.SetOrigin( self, pev.origin );
         g_EntityFuncs.SetSize( self.pev, g_vecZero, g_vecZero );
 
-        NetworkMessage m2( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+        NetworkMessage m2( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
         m2.WriteByte( TE_BEAMFOLLOW );
         m2.WriteShort( self.entindex() );
         m2.WriteShort( models::laserbeam );

--- a/scripts/maps/bts_rc/entities/weapons/Melee/axe.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/axe.as
@@ -146,7 +146,7 @@ final class weapon_bts_axe : BTS_MeleeWeapon
         }
         else
         {
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh(hit) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Melee/broom.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/broom.as
@@ -144,7 +144,7 @@ class weapon_bts_broom : BTS_MeleeWeapon
                 }
             }
 
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh( hit ) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Melee/crowbar.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/crowbar.as
@@ -87,7 +87,7 @@ final class ASWeaponCrowbarConfig : ASWeaponConfig
         bool miss = weapons::Hit( weapon, player, tr, AttackType::Primary, void, gpWeaponCrowbarConfig );
 
         if( !miss )
-            weapons::TraceEffects( weapon, player, gpWeaponCrowbarConfig, tr, Bullet::BULLET_PLAYER_CROWBAR );
+            weapons::TraceEffects( weapon, player, gpWeaponCrowbarConfig, tr );
 
         weapons::SetCooldown( weapon, player, gpWeaponCrowbarConfig.GetCooldown( util::IsTrainedPersonal(player), AttackType::Primary, miss ) );
     }
@@ -122,7 +122,7 @@ final class ASWeaponCrowbarConfig : ASWeaponConfig
                 case 2: weapon.SendWeaponAnim( WeaponCrowbarAnim::Shove, 0, body ); break;
             }
 
-            weapons::TraceEffects( weapon, player, gpWeaponCrowbarConfig, tr, Bullet::BULLET_PLAYER_CROWBAR );
+            weapons::TraceEffects( weapon, player, gpWeaponCrowbarConfig, tr );
         }
 
         weapons::SetCooldown( weapon, player, gpWeaponCrowbarConfig.GetCooldown( util::IsTrainedPersonal( player ), AttackType::Secondary, miss ) );
@@ -161,7 +161,7 @@ final class ASWeaponCrowbarConfig : ASWeaponConfig
                         @tr.pHit = info.pVictim.edict();
                         //tr.iHitgroup = cast<CBaseMonster@>( info.pVictim ).m_LastHitGroup;
                         tr.iHitgroup = lastHitgroup;
-                        weapons::TraceEffects( cast<CBasePlayerWeapon@>(info.pInflictor), cast<CBasePlayer@>(info.pAttacker), gpWeaponCrowbarConfig, tr, Bullet::BULLET_PLAYER_CROWBAR );
+                        weapons::TraceEffects( cast<CBasePlayerWeapon@>(info.pInflictor), cast<CBasePlayer@>(info.pAttacker), gpWeaponCrowbarConfig, tr );
                     }
                 }
                 return HOOK_CONTINUE;

--- a/scripts/maps/bts_rc/entities/weapons/Melee/knife.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/knife.as
@@ -170,7 +170,7 @@ final class weapon_bts_knife : BTS_MeleeCharge
         }
         else
         {
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh(hit) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Melee/pipe.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/pipe.as
@@ -147,7 +147,7 @@ final class weapon_bts_pipe : BTS_MeleeCharge
         }
         else
         {
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh(hit) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Melee/pipewrench.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/pipewrench.as
@@ -194,7 +194,7 @@ final class weapon_bts_pipewrench : BTS_MeleeCharge
         this.SetCooldown( is_trained_personal, miss, type );
 
         if( !miss )
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
     }
 
     float Idle() override

--- a/scripts/maps/bts_rc/entities/weapons/Melee/poolstick.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/poolstick.as
@@ -145,7 +145,7 @@ final class weapon_bts_poolstick : BTS_MeleeWeapon
         }
         else
         {
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh(hit) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Melee/screwdriver.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/screwdriver.as
@@ -114,7 +114,7 @@ final class weapon_bts_screwdriver : BTS_MeleeWeapon
         }
         else
         {
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh(hit) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Melee/spanner.as
+++ b/scripts/maps/bts_rc/entities/weapons/Melee/spanner.as
@@ -134,7 +134,7 @@ class weapon_bts_spanner : BTS_MeleeWeapon
                 }
             }
 
-            TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+            TraceEffects(tr);
 
             if( this.IsFlesh( hit ) )
             {

--- a/scripts/maps/bts_rc/entities/weapons/Special/flashlight.as
+++ b/scripts/maps/bts_rc/entities/weapons/Special/flashlight.as
@@ -134,7 +134,7 @@ final class weapon_bts_flashlight : BTS_MeleeWeapon
             return;
         }
 
-        TraceEffects( tr, Bullet::BULLET_PLAYER_CROWBAR );
+        TraceEffects(tr);
 
         if( this.IsFlesh( hit ) )
         {

--- a/scripts/maps/bts_rc/entities/weapons/base/BTS_FireWeapon.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/BTS_FireWeapon.as
@@ -110,14 +110,14 @@ abstract class BTS_FireWeapon : BTS_Weapon
             return;
         }
 
-        Flashlight::TurnOff( this.owner, self, this.config );
+        Flashlight::TurnOff( this.owner, self, config );
 
         int anim = ( self.m_iClip != 0 ) ? config.reload_anim : config.reload_empty_anim;
         self.DefaultReload( config.max_clip, anim, config.reload_time, this.body );
         self.m_flTimeWeaponIdle = g_Engine.time + Math.RandomFloat( 10.0f, 15.0f );
         if( !config.reload_sound.IsEmpty() )
         {
-            PlaySound( config.reload_sound, 0.2f );
+            PlaySound( this.config.reload_sound, 0.2f );
         }
         BaseClass.Reload();
     }

--- a/scripts/maps/bts_rc/entities/weapons/base/BTS_FireWeapon.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/BTS_FireWeapon.as
@@ -81,7 +81,7 @@ abstract class BTS_FireWeapon : BTS_Weapon
         TraceResult tr;
         g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
         self.FireBullets( cShots, vecSrc, vecDir, g_vecZero, 8192.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int( flDamage ), player.pev );
-        TraceEffects( tr, Bullet::BULLET_PLAYER_CUSTOMDAMAGE );
+        TraceEffects(tr);
 
         PlayAnim( shootAnim );
         PlaySound( szSound, flVolume, iPitch );

--- a/scripts/maps/bts_rc/entities/weapons/base/BTS_Weapon.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/BTS_Weapon.as
@@ -203,9 +203,9 @@ abstract class BTS_Weapon : ScriptBasePlayerWeaponEntity
         }
     }
 
-    void TraceEffects( TraceResult &in tr, Bullet bullet = Bullet::BULLET_NONE )
+    void TraceEffects( TraceResult &in tr )
     {
-        weapons::TraceEffects( self, this.owner, this.config, tr, bullet );
+        weapons::TraceEffects( self, this.owner, this.config, tr );
     }
 
     protected uint8 __last_random__ = 0;

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/Hit.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/Hit.as
@@ -54,10 +54,12 @@ namespace weapons
                 {
                     g_Utility.FindHullIntersection( vecSrc, tr, tr, VEC_DUCK_HULL_MIN, VEC_DUCK_HULL_MAX, player.edict() );
                 }
-
-                vecEnd = tr.vecEndPos; // This is the point on the actual surface (the hull could have hit space)
             }
         }
+
+        CSoundEnt@ sound = GetSoundEntInstance();
+        sound.InsertSound( bits_SOUND_COMBAT, tr.vecEndPos, 2048, 0.3, player );
+        g_WeaponFuncs.DecalGunshot( tr, Bullet::BULLET_PLAYER_CROWBAR );
 
         if( hit !is null || ( tr.pHit !is null && ( @hit = g_EntityFuncs.Instance( tr.pHit ) ) !is null ) )
         {

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/Kickback.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/Kickback.as
@@ -1,17 +1,17 @@
 /**
 *   Copyright (c) 2026 Mikk155 and contributors of bts_rc
-*   
+*
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software to use, copy, modify, merge, publish, distribute, sublicense,
 *   and/or sell copies of the Software under the following conditions:
-*   
+*
 *   A reference to the original project must be included in all copies or substantial
 *   portions of the Software. This must include, at minimum, a URL to:
 *   https://github.com/Mikk155/bts_rc
-*   
+*
 *   The above copyright notice and this permission notice shall be included in all
 *   copies of the Software when distributed as a whole.
-*   
+*
 *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
 **/
 

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/Kickback.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/Kickback.as
@@ -1,0 +1,43 @@
+/**
+*   Copyright (c) 2026 Mikk155 and contributors of bts_rc
+*   
+*   Permission is hereby granted, free of charge, to any person obtaining a copy
+*   of this software to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software under the following conditions:
+*   
+*   A reference to the original project must be included in all copies or substantial
+*   portions of the Software. This must include, at minimum, a URL to:
+*   https://github.com/Mikk155/bts_rc
+*   
+*   The above copyright notice and this permission notice shall be included in all
+*   copies of the Software when distributed as a whole.
+*   
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+**/
+
+namespace weapons
+{
+    // Set the proper player view angle based if is crouching/standing and trained personal
+    void Kickback( CBasePlayer@ player, float[] values, bool is_trained_personal )
+    {
+        float modifier = 0;
+
+        if( player.IsMoving() )
+            modifier = values[ is_trained_personal ? 5 : 4 ];
+        else if( ( player.pev.button & IN_DUCK ) != 0 )
+            modifier = values[ is_trained_personal ? 3 : 2 ];
+        else
+            modifier = values[ is_trained_personal ? 1 : 0 ];
+
+        if( int( values[6] ) != 0 )
+            player.pev.punchangle.x = modifier;
+        else
+            player.pev.punchangle.x -= modifier;
+    }
+
+    // Set the proper player view angle based if is crouching/standing and trained personal
+    void Kickback( CBasePlayer@ player, float[] values )
+    {
+        Kickback( player, values, util::IsTrainedPersonal( player ) );
+    }
+}

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/TraceEffects.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/TraceEffects.as
@@ -18,42 +18,8 @@
 namespace weapons
 {
     // Play effects
-    void TraceEffects( CBasePlayerWeapon@ weapon, CBasePlayer@ player, ASWeaponConfig@ config, TraceResult &in tr, Bullet bullet = Bullet::BULLET_NONE )
+    void TraceEffects( CBasePlayerWeapon@ weapon, CBasePlayer@ player, ASWeaponConfig@ config, TraceResult &in tr )
     {
-        if( bullet != Bullet::BULLET_NONE )
-        {
-            g_WeaponFuncs.DecalGunshot( tr, bullet );
-            g_SoundSystem.PlayHitSound( tr, ( player !is null ? player.GetGunPosition() : g_vecZero ), tr.vecEndPos, bullet );
-
-            CSoundEnt@ sound = GetSoundEntInstance();
-            sound.InsertSound( bits_SOUND_COMBAT, player.pev.origin, 2048, 0.3, player );
-
-            switch( bullet )
-            {
-                case Bullet::BULLET_PLAYER_9MM:
-                case Bullet::BULLET_PLAYER_MP5:
-                case Bullet::BULLET_PLAYER_SAW:
-                case Bullet::BULLET_PLAYER_SNIPER:
-                case Bullet::BULLET_PLAYER_357:
-                case Bullet::BULLET_PLAYER_EAGLE:
-                case Bullet::BULLET_PLAYER_BUCKSHOT:
-                {
-                    if( player !is null )
-                    {
-                        player.pev.effects |= EF_MUZZLEFLASH;
-                    }
-
-                    // Bullet impact
-                    sound.InsertSound( bits_SOUND_COMBAT, tr.vecEndPos, 1024, 0.3, player );
-                    break;
-                }
-                case Bullet::BULLET_PLAYER_CROWBAR:
-                case Bullet::BULLET_NONE:
-                default:
-                    break;
-            }
-        }
-
         CBaseEntity@ hit = null;
         CBaseMonster@ monster = null;
 
@@ -136,7 +102,7 @@ namespace weapons
                     case 4: g_SoundSystem.EmitSoundDyn( hit.edict(), CHAN_AUTO, "weapons/ric5.wav", 1.0, ATTN_NONE, 0, PITCH_NORM ); break;
                 }
 
-                NetworkMessage m( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+                NetworkMessage m( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
                     m.WriteByte( TE_STREAK_SPLASH );
                     m.WriteCoord( tr.vecEndPos.x );
                     m.WriteCoord( tr.vecEndPos.y );
@@ -150,7 +116,7 @@ namespace weapons
                     m.WriteShort( 100 );         // Random velocity
                 m.End();
 
-                NetworkMessage m2( MSG_BROADCAST, NetworkMessages::SVC_TEMPENTITY );
+                NetworkMessage m2( MSG_PVS, NetworkMessages::SVC_TEMPENTITY );
                     m2.WriteByte( TE_DLIGHT );
                     m2.WriteCoord( tr.vecEndPos.x );
                     m2.WriteCoord( tr.vecEndPos.y );

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
@@ -1,0 +1,202 @@
+/**
+*   Copyright (c) 2026 Mikk155 and contributors of bts_rc
+*   
+*   Permission is hereby granted, free of charge, to any person obtaining a copy
+*   of this software to use, copy, modify, merge, publish, distribute, sublicense,
+*   and/or sell copies of the Software under the following conditions:
+*   
+*   A reference to the original project must be included in all copies or substantial
+*   portions of the Software. This must include, at minimum, a URL to:
+*   https://github.com/Mikk155/bts_rc
+*   
+*   The above copyright notice and this permission notice shall be included in all
+*   copies of the Software when distributed as a whole.
+*   
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
+**/
+
+final class ASBullet
+{
+    private bool m_Underwater;
+    private uint m_Shots;
+    private int m_FlashSize;
+    private bool m_FlashLight;
+    private int m_ShellModel;
+    private TE_BOUNCE m_ShellType;
+    private int m_WeaponVolume;
+    private string m_SoundName;
+    private float m_Volume;
+    private int m_Pitch;
+    private float m_Attenuation;
+
+    // Amount of shots to fire (Shotguns would trace multiple pellets)
+    ASBullet@ Shots( uint shots = 1 )
+    {
+        this.m_Shots = shots;
+        return this;
+    }
+
+    // Whatever we can shoot under water
+    ASBullet@ CanUseInWater( bool shootInWater = false )
+    {
+        this.m_Underwater = shootInWater;
+        return this;
+    }
+
+    // Set muzzle flash size, -1 to not use muzzle flash at all
+    ASBullet@ Flash( int flash = NORMAL_GUN_FLASH, bool dlight = true )
+    {
+        this.m_FlashSize = flash;
+        this.m_FlashLight = dlight;
+        return this;
+    }
+
+    // Sound to emit
+    ASBullet@ Sound(
+        const string &in soundName = String::EMPTY_STRING,
+        float volume = 1.0,
+        int pitch = PITCH_NORM,
+        int weaponVolume = NORMAL_GUN_VOLUME,
+        float attenuation = ATTN_NORM
+    )
+    {
+        this.m_Pitch = pitch;
+        this.m_Attenuation = attenuation;
+        this.m_Volume = volume;
+        this.m_WeaponVolume = weaponVolume;
+        this.m_SoundName = soundName;
+        return this;
+    }
+
+    // Shell model, -1 to not throw any shell. by default uses models::shell
+    ASBullet@ Shell( int shellModel = -2, TE_BOUNCE shellType = TE_BOUNCE_SHELL )
+    {
+        if( shellModel == -2 )
+            shellModel = models::shell;
+
+        this.m_ShellModel = shellModel;
+        this.m_ShellType = shellType;
+        return this;
+    }
+
+    ASBullet@ Clear()
+    {
+        return this
+            .Shots()
+            .CanUseInWater()
+            .Flash()
+            .Sound()
+            .Shell();
+    }
+
+    // Fire bullet
+    void Fire( CBasePlayer@ player, BTS_Weapon@ weaponClass, AttackType attackType, ASWeaponConfig@ config, int Animation )
+    {
+        CBasePlayerWeapon@ weapon = weaponClass.Entity;
+
+        int ammo;
+
+        switch( attackType )
+        {
+            case AttackType::Primary:
+            {
+                if( config.max_clip != WEAPON_NOCLIP )
+                    ammo = weapon.m_iClip;
+                else
+                    ammo = player.m_rgAmmo( weapon.m_iPrimaryAmmoType );
+                break;
+            }
+            case AttackType::Secondary:
+            {
+                ammo = player.m_rgAmmo( weapon.m_iSecondaryAmmoType );
+            }
+        }
+
+        bool isTrainedPersonal = util::IsTrainedPersonal( player );
+
+        weapons::SetCooldown( weapon, player, config.GetCooldown( isTrainedPersonal, attackType ) );
+
+        if( ( ammo <= 0 ) || ( !m_Underwater && player.pev.waterlevel == WATERLEVEL_HEAD ) )
+        {
+            weapon.PlayEmptySound();
+            this.Clear();
+            return;
+        }
+
+        float damage;
+        float coneAccuracy;
+
+        switch( attackType )
+        {
+            case AttackType::Primary:
+            {
+                if( config.max_clip != WEAPON_NOCLIP )
+                    --weapon.m_iClip;
+                else
+                    player.m_rgAmmo( weapon.m_iPrimaryAmmoType, --ammo );
+
+                damage = config.primary_damage;
+                coneAccuracy = weapons::Accuracy( player, config.primary_accuracy, isTrainedPersonal );
+                break;
+            }
+            case AttackType::Secondary:
+            {
+                player.m_rgAmmo( weapon.m_iSecondaryAmmoType, --ammo );
+                damage = config.secondary_damage;
+                coneAccuracy = weapons::Accuracy( player, config.secondary_accuracy, isTrainedPersonal );
+            }
+        }
+
+        player.m_iWeaponVolume = this.m_WeaponVolume;
+
+        player.m_iWeaponFlash = this.m_FlashSize;
+
+        if( ammo <= 0 && util::IsHEV( player ) )
+        {
+            player.SetSuitUpdate( "!HEV_AMO0", false, 0 );
+        }
+
+        if( m_FlashLight )
+        {
+            player.pev.effects |= EF_MUZZLEFLASH;
+            weapon.pev.effects |= EF_MUZZLEFLASH;
+        }
+
+        Math.MakeVectors( player.pev.v_angle + player.pev.punchangle );
+        Vector vecSrc = player.GetGunPosition();
+        Vector vecAiming = player.GetAutoaimVector( AUTOAIM_5DEGREES );
+
+        float x, y;
+        g_Utility.GetCircularGaussianSpread( x, y );
+
+        Vector vecDir = vecAiming + x * coneAccuracy * g_Engine.v_right + y * coneAccuracy * g_Engine.v_up;
+        Vector vecEnd = vecSrc + vecDir * 8192.0f;
+
+        TraceResult tr;
+        g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
+        weapon.FireBullets( m_Shots, vecSrc, vecDir, g_vecZero, 8192.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int(damage), player.pev );
+
+        if( this.m_ShellModel > -1 )
+        {
+            Vector vecForward, vecRight, vecUp;
+            g_EngineFuncs.AngleVectors( player.pev.v_angle, vecForward, vecRight, vecUp );
+            Vector vecOrigin = player.GetGunPosition() + vecForward * 32.0f + vecRight * 6.0f - vecUp * 12.0f;
+            Vector vecVelocity = player.pev.velocity + vecForward * 25.0f + vecRight * Math.RandomFloat( 50.0f, 70.0f ) + vecUp * Math.RandomFloat( 100.0f, 150.0f );
+            float flYaw = player.pev.v_angle.y;
+            g_EntityFuncs.EjectBrass( vecOrigin, vecVelocity, flYaw, this.m_ShellModel, this.m_ShellType );
+        }
+
+        g_SoundSystem.EmitSoundDyn( weapon.edict(), SOUND_CHANNEL::CHAN_WEAPON, this.m_SoundName, this.m_Volume, this.m_Attenuation, 0, this.m_Pitch );
+
+        weapon.SendWeaponAnim( Animation, 0, weaponClass.body );
+
+        AttackKickback( player, attackType );
+
+        player.SetAnimation( PLAYER_ANIM::PLAYER_ATTACK1 );
+
+        this.Clear();
+    }
+}
+
+// Configure a bullet using Builder-Patterns and fire it.
+ASBullet bullet;

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
@@ -112,7 +112,7 @@ final class ASBullet
             case 512:
                 break;
             default:
-                g_Logger.critical.print( "Weapon {} called buller.Flash with value higher than 1.0!other than DIM_GUN_FLASH, BRIGHT_GUN_FLASH or NORMAL_GUN_FLASH!", { this.m_Config.GetName() } );
+                g_Logger.critical.print( "Weapon {} called bullet.Flash with value other than DIM_GUN_FLASH, BRIGHT_GUN_FLASH or NORMAL_GUN_FLASH!", { this.m_Config.GetName() } );
         }
 #endif
         this.m_FlashSize = flash;
@@ -126,11 +126,11 @@ final class ASBullet
 #if SERVER
         if( volume > 1.0 )
         {
-            g_Logger.critical.print( "Weapon {} called buller.Volume with value higher than 1.0!", { this.m_Config.GetName() } );
+            g_Logger.critical.print( "Weapon {} called bullet.Volume with value higher than 1.0!", { this.m_Config.GetName() } );
         }
         else if( volume <= 0.0 )
         {
-            g_Logger.critical.print( "Weapon {} called buller.Volume with value lower than 0.0!", { this.m_Config.GetName() } );
+            g_Logger.critical.print( "Weapon {} called bullet.Volume with value lower than 0.0!", { this.m_Config.GetName() } );
         }
 #endif
 

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
@@ -15,6 +15,8 @@
 *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
 **/
 
+funcdef void FireBulletCallback( TraceResult&in );
+
 final class ASBullet
 {
     private bool m_Underwater;
@@ -28,6 +30,61 @@ final class ASBullet
     private float m_Volume;
     private int m_Pitch;
     private float m_Attenuation;
+    private CBasePlayer@ m_Player;
+    private BTS_Weapon@ m_Weapon;
+    private CBasePlayerWeapon@ m_WeaponEntity;
+    private ASWeaponConfig@ m_Config;
+    private AttackType m_AttackType;
+    private uint m_WeaponAnim;
+    private PLAYER_ANIM m_PlayerAnim;
+    private int m_PlayerAnimMode;
+    private bool m_PlayerIsTrainedPersonal;
+    private FireBulletCallback@ m_Callback;
+    private Bullet m_BulletType;
+
+    // Set a custom logic instead of our FireBullets call you fire it yourself using a class or something
+    ASBullet@ Callback( FireBulletCallback@ callback = null )
+    {
+        @this.m_Callback = callback;
+        return this;
+    }
+
+    // Animation
+    ASBullet@ Animation( uint weaponAnim = 0, PLAYER_ANIM playerAnim = PLAYER_ANIM::PLAYER_ATTACK1, int playerAnimMode = 0 )
+    {
+        this.m_WeaponAnim = weaponAnim;
+        this.m_PlayerAnim = playerAnim;
+        this.m_PlayerAnimMode = playerAnimMode;
+        return this;
+    }
+
+    // Weapon that is shooting
+    ASBullet@ Weapon( BTS_Weapon@ weapon = null )
+    {
+        if( weapon is null )
+        {
+            @this.m_Weapon = null;
+            @this.m_Player = null;
+            @this.m_Config = null;
+            return this;
+        }
+
+        @this.m_Weapon = weapon;
+        @this.m_Player = weapon.owner;
+        @this.m_Config = weapon.config;
+        @this.m_WeaponEntity = weapon.Entity;
+
+        this.m_PlayerIsTrainedPersonal = util::IsTrainedPersonal( this.m_Player );
+
+        return this;
+    }
+
+    // AttackType we're launching
+    ASBullet@ Type( AttackType type = AttackType::Primary )
+    {
+        this.m_AttackType = type;
+        return this;
+    }
 
     // Amount of shots to fire (Shotguns would trace multiple pellets)
     ASBullet@ Shots( uint shots = 1 )
@@ -43,11 +100,42 @@ final class ASBullet
         return this;
     }
 
-    // Set muzzle flash size, -1 to not use muzzle flash at all
+    // Set muzzle flash size, 0 to not use muzzle flash at all
     ASBullet@ Flash( int flash = NORMAL_GUN_FLASH, bool dlight = true )
     {
+#if SERVER
+        switch( flash )
+        {
+            case 0:
+            case 128:
+            case 256:
+            case 512:
+                break;
+            default:
+                g_Logger.critical.print( "Weapon {} called buller.Flash with value higher than 1.0!other than DIM_GUN_FLASH, BRIGHT_GUN_FLASH or NORMAL_GUN_FLASH!", { this.m_Config.GetName() } );
+        }
+#endif
         this.m_FlashSize = flash;
         this.m_FlashLight = dlight;
+        return this;
+    }
+
+    // Volume for sound
+    ASBullet@ Volume( float volume = 1.0, int weaponVolume = NORMAL_GUN_VOLUME )
+    {
+#if SERVER
+        if( volume > 1.0 )
+        {
+            g_Logger.critical.print( "Weapon {} called buller.Volume with value higher than 1.0!", { this.m_Config.GetName() } );
+        }
+        else if( volume <= 0.0 )
+        {
+            g_Logger.critical.print( "Weapon {} called buller.Volume with value lower than 0.0!", { this.m_Config.GetName() } );
+        }
+#endif
+
+        this.m_Volume = volume;
+        this.m_WeaponVolume = weaponVolume;
         return this;
     }
 
@@ -62,8 +150,7 @@ final class ASBullet
     {
         this.m_Pitch = pitch;
         this.m_Attenuation = attenuation;
-        this.m_Volume = volume;
-        this.m_WeaponVolume = weaponVolume;
+        Volume( volume, weaponVolume );
         this.m_SoundName = soundName;
         return this;
     }
@@ -86,126 +173,258 @@ final class ASBullet
             .CanUseInWater()
             .Flash()
             .Sound()
-            .Shell();
+            .Shell()
+            .Type()
+            .Weapon()
+            .Animation()
+            .Callback();
+    }
+
+    // Return ammo count for the current type
+    int get_CurrentAmmo() property
+    {
+        switch( this.m_AttackType )
+        {
+            case AttackType::Primary:
+            {
+                if( this.m_Config.max_clip != WEAPON_NOCLIP )
+                    return this.m_WeaponEntity.m_iClip;
+                return this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iPrimaryAmmoType );
+            }
+            case AttackType::Secondary:
+            {
+                return this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iSecondaryAmmoType );
+            }
+            default:
+                return 0;
+        }
+    }
+
+    float get_Damage() property
+    {
+        switch( this.m_AttackType )
+        {
+            case AttackType::Primary:
+            {
+                return this.m_Config.primary_damage;
+            }
+            case AttackType::Secondary:
+            {
+                return this.m_Config.secondary_damage;
+            }
+            default:
+                return 0;
+        }
+    }
+
+    float get_Accuracy() property
+    {
+        switch( this.m_AttackType )
+        {
+            case AttackType::Primary:
+            {
+                return weapons::Accuracy( this.m_Player, this.m_Config.primary_accuracy, this.m_PlayerIsTrainedPersonal );
+            }
+            case AttackType::Secondary:
+            {
+                return weapons::Accuracy( this.m_Player, this.m_Config.secondary_accuracy, this.m_PlayerIsTrainedPersonal );
+            }
+            default:
+                return 0;
+        }
+    }
+
+    void DeduceAmmo( uint value )
+    {
+        if( g_WeaponsConfig.infinite_ammo )
+            return;
+
+        int ammo = CurrentAmmo - value;
+
+        switch( this.m_AttackType )
+        {
+            case AttackType::Primary:
+            {
+                if( this.m_Config.max_clip != WEAPON_NOCLIP )
+                    this.m_WeaponEntity.m_iClip = ammo;
+                else
+                    this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iPrimaryAmmoType, ammo );
+                break;
+            }
+            case AttackType::Secondary:
+            {
+                this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iSecondaryAmmoType, ammo );
+                break;
+            }
+        }
+
+        if( ammo <= 0 && util::IsHEV( this.m_Player ) )
+        {
+            this.m_Player.SetSuitUpdate( "!HEV_AMO0", false, 0 );
+        }
+    }
+
+    float get_Distance() property
+    {
+        return 8192;
     }
 
     // Fire bullet
-    void Fire( CBasePlayer@ player, BTS_Weapon@ weaponClass, AttackType attackType, ASWeaponConfig@ config, int Animation )
+    // If something in here is needed they could be moved to methods just like this.DeduceAmmo, get_Damage etc
+    bool Fire()
     {
-        CBasePlayerWeapon@ weapon = weaponClass.Entity;
+        int ammo = CurrentAmmo;
 
-        int ammo;
+        weapons::SetCooldown( this.m_WeaponEntity, this.m_Player, this.m_Config.GetCooldown( this.m_PlayerIsTrainedPersonal, this.m_AttackType ) );
 
-        switch( attackType )
+        if( ( ammo <= 0 ) || ( !this.m_Underwater && this.m_Player.pev.waterlevel == WATERLEVEL_HEAD ) )
         {
-            case AttackType::Primary:
-            {
-                if( config.max_clip != WEAPON_NOCLIP )
-                    ammo = weapon.m_iClip;
-                else
-                    ammo = player.m_rgAmmo( weapon.m_iPrimaryAmmoType );
-                break;
-            }
-            case AttackType::Secondary:
-            {
-                ammo = player.m_rgAmmo( weapon.m_iSecondaryAmmoType );
-            }
+            this.m_WeaponEntity.PlayEmptySound();
+            Clear();
+            return false;
         }
 
-        bool isTrainedPersonal = util::IsTrainedPersonal( player );
+        Vector gunPosition = this.m_Player.GetGunPosition();
 
-        weapons::SetCooldown( weapon, player, config.GetCooldown( isTrainedPersonal, attackType ) );
-
-        if( ( ammo <= 0 ) || ( !m_Underwater && player.pev.waterlevel == WATERLEVEL_HEAD ) )
-        {
-            weapon.PlayEmptySound();
-            this.Clear();
-            return;
-        }
-
-        float damage;
-        float coneAccuracy;
-
-        switch( attackType )
-        {
-            case AttackType::Primary:
-            {
-                if( config.max_clip != WEAPON_NOCLIP )
-                    --weapon.m_iClip;
-                else
-                    player.m_rgAmmo( weapon.m_iPrimaryAmmoType, --ammo );
-
-                damage = config.primary_damage;
-                coneAccuracy = weapons::Accuracy( player, config.primary_accuracy, isTrainedPersonal );
-                break;
-            }
-            case AttackType::Secondary:
-            {
-                player.m_rgAmmo( weapon.m_iSecondaryAmmoType, --ammo );
-                damage = config.secondary_damage;
-                coneAccuracy = weapons::Accuracy( player, config.secondary_accuracy, isTrainedPersonal );
-            }
-        }
-
-        player.m_iWeaponVolume = this.m_WeaponVolume;
-
-        player.m_iWeaponFlash = this.m_FlashSize;
-
-        if( ammo <= 0 && util::IsHEV( player ) )
-        {
-            player.SetSuitUpdate( "!HEV_AMO0", false, 0 );
-        }
-
-        if( m_FlashLight )
-        {
-            player.pev.effects |= EF_MUZZLEFLASH;
-            weapon.pev.effects |= EF_MUZZLEFLASH;
-        }
-
-        Math.MakeVectors( player.pev.v_angle + player.pev.punchangle );
-        Vector vecSrc = player.GetGunPosition();
-        Vector vecAiming = player.GetAutoaimVector( AUTOAIM_5DEGREES );
+        Math.MakeVectors( this.m_Player.pev.v_angle + this.m_Player.pev.punchangle );
+        Vector vecSrc = gunPosition;
+        Vector vecAiming = this.m_Player.GetAutoaimVector( AUTOAIM_5DEGREES );
 
         float x, y;
         g_Utility.GetCircularGaussianSpread( x, y );
 
+        float coneAccuracy = this.Accuracy;
+
         Vector vecDir = vecAiming + x * coneAccuracy * g_Engine.v_right + y * coneAccuracy * g_Engine.v_up;
-        Vector vecEnd = vecSrc + vecDir * 8192.0f;
 
         TraceResult tr;
-        g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, player.edict(), tr );
-        weapon.FireBullets( m_Shots, vecSrc, vecDir, g_vecZero, 8192.0f, BULLET_PLAYER_CUSTOMDAMAGE, 0, int(damage), player.pev );
+
+        if( this.m_Callback !is null )
+        {
+            Vector vecEnd = vecSrc + vecDir * this.Distance;
+            g_Utility.TraceLine( vecSrc, vecEnd, dont_ignore_monsters, this.m_Player.edict(), tr );
+            this.m_Callback( tr );
+        }
+        else
+        {
+            this.m_WeaponEntity.FireBullets(
+                this.m_Shots,
+                vecSrc,
+                vecDir,
+                g_vecZero,
+                this.Distance,
+                Bullet::BULLET_PLAYER_CUSTOMDAMAGE,
+                0,
+                int(this.Damage),
+                this.m_Player.pev
+            );
+
+            // God bless valve
+            tr.fAllSolid = int(g_Engine.trace_allsolid);
+            tr.fStartSolid = int(g_Engine.trace_startsolid);
+            tr.flFraction = g_Engine.trace_fraction;
+            tr.vecEndPos = g_Engine.trace_endpos;
+            tr.vecPlaneNormal = g_Engine.trace_plane_normal;
+            tr.flPlaneDist = g_Engine.trace_plane_dist;
+            // stupid sven API
+            @tr.pHit = g_EngineFuncs.PEntityOfEntIndex( g_EngineFuncs.IndexOfEdict( g_Engine.trace_ent ) ); // when const_cast
+            tr.fInOpen = int(g_Engine.trace_inopen);
+            tr.fInWater = int(g_Engine.trace_inwater);
+            tr.iHitgroup = g_Engine.trace_hitgroup;
+        }
+
+        weapons::TraceEffects( this.m_WeaponEntity, this.m_Player, this.m_Config, tr );
+
+        // -TODO Move these to build-pattern option when silencer weapons are made
+        CSoundEnt@ sound = GetSoundEntInstance();
+        sound.InsertSound( bits_SOUND_PLAYER, gunPosition, 2048, 0.3, this.m_Player );
+        // Bullet impact
+        sound.InsertSound( bits_SOUND_COMBAT, tr.vecEndPos, 1024, 0.3, this.m_Player );
+
+        this.m_Player.m_iWeaponVolume = this.m_WeaponVolume;
+        this.m_Player.m_iWeaponFlash = this.m_FlashSize;
+
+        if( this.m_FlashLight )
+        {
+            this.m_Player.pev.effects |= EF_MUZZLEFLASH;
+            this.m_WeaponEntity.pev.effects |= EF_MUZZLEFLASH;
+        }
+
+        g_SoundSystem.EmitSoundDyn( this.m_WeaponEntity.edict(), SOUND_CHANNEL::CHAN_WEAPON, this.m_SoundName, this.m_Volume, this.m_Attenuation, 0, this.m_Pitch );
+
+        this.m_WeaponEntity.SendWeaponAnim( this.m_WeaponAnim, 0, this.m_Weapon.body );
+
+        this.m_Player.SetAnimation( this.m_PlayerAnim );
+
+        g_Utility.BubbleTrail( gunPosition, tr.vecEndPos, 16 );
+
+        {
+            Vector playerHandPosition;
+            g_EngineFuncs.GetAttachment( this.m_Player.edict(), 0, playerHandPosition, void );
+            playerHandPosition = playerHandPosition + g_Engine.v_forward * 64 + g_Engine.v_right * 2;
+
+            NetworkMessage msg( MSG_PVS, NetworkMessages::SVC_TEMPENTITY, null );
+                msg.WriteByte( TE_TRACER );
+                msg.WriteCoord( playerHandPosition.x );
+                msg.WriteCoord( playerHandPosition.y );
+                msg.WriteCoord( playerHandPosition.z );
+                msg.WriteCoord( tr.vecEndPos.x );
+                msg.WriteCoord( tr.vecEndPos.y );
+                msg.WriteCoord( tr.vecEndPos.z );
+            msg.End();
+        }
+
+        if( this.m_FlashLight )
+        {
+            NetworkMessage msg( MSG_PVS, NetworkMessages::SVC_TEMPENTITY, gunPosition );
+                msg.WriteByte( TE_DLIGHT );
+                msg.WriteCoord( gunPosition.x );
+                msg.WriteCoord( gunPosition.y );
+                msg.WriteCoord( gunPosition.z );
+
+                if( this.m_FlashSize >= BRIGHT_GUN_FLASH )
+                    msg.WriteByte( 30 );
+                if( this.m_FlashSize >= NORMAL_GUN_FLASH )
+                    msg.WriteByte( 20 );
+                else
+                    msg.WriteByte( 10 );
+
+                msg.WriteByte( 255 );
+                msg.WriteByte( 200 );
+                msg.WriteByte( 150 );
+                msg.WriteByte( 1 );
+                msg.WriteByte( 100 );
+            msg.End();
+        }
 
         if( this.m_ShellModel > -1 )
         {
             Vector vecForward, vecRight, vecUp;
-            g_EngineFuncs.AngleVectors( player.pev.v_angle, vecForward, vecRight, vecUp );
-            Vector vecOrigin = player.GetGunPosition() + vecForward * 32.0f + vecRight * 6.0f - vecUp * 12.0f;
-            Vector vecVelocity = player.pev.velocity + vecForward * 25.0f + vecRight * Math.RandomFloat( 50.0f, 70.0f ) + vecUp * Math.RandomFloat( 100.0f, 150.0f );
-            float flYaw = player.pev.v_angle.y;
+            g_EngineFuncs.AngleVectors( this.m_Player.pev.v_angle, vecForward, vecRight, vecUp );
+            Vector vecOrigin = gunPosition + vecForward * 32.0f + vecRight * 6.0f - vecUp * 12.0f;
+            Vector vecVelocity = this.m_Player.pev.velocity + vecForward * 25.0f + vecRight * Math.RandomFloat( 50.0f, 70.0f ) + vecUp * Math.RandomFloat( 100.0f, 150.0f );
+            float flYaw = this.m_Player.pev.v_angle.y;
             g_EntityFuncs.EjectBrass( vecOrigin, vecVelocity, flYaw, this.m_ShellModel, this.m_ShellType );
         }
 
-        g_SoundSystem.EmitSoundDyn( weapon.edict(), SOUND_CHANNEL::CHAN_WEAPON, this.m_SoundName, this.m_Volume, this.m_Attenuation, 0, this.m_Pitch );
+        this.DeduceAmmo(1);
 
-        weapon.SendWeaponAnim( Animation, 0, weaponClass.body );
-
-        player.SetAnimation( PLAYER_ANIM::PLAYER_ATTACK1 );
-
-        switch( attackType )
+        switch( this.m_AttackType )
         {
             case AttackType::Primary:
             {
-                weapons::Kickback( player, config.primary_kickback, isTrainedPersonal );
+                weapons::Kickback( this.m_Player, this.m_Config.primary_kickback, this.m_PlayerIsTrainedPersonal );
                 break;
             }
             case AttackType::Secondary:
             {
-                weapons::Kickback( player, config.secondary_kickback, isTrainedPersonal );
+                weapons::Kickback( this.m_Player, this.m_Config.secondary_kickback, this.m_PlayerIsTrainedPersonal );
             }
         }
 
-        this.Clear();
+        Clear();
+
+        return true;
     }
 }
 

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
@@ -240,6 +240,8 @@ final class ASBullet
             return;
 
         int ammo = CurrentAmmo - value;
+        int maxAmmo;
+        int totalAmmo;
 
         switch( this.m_AttackType )
         {
@@ -249,18 +251,38 @@ final class ASBullet
                     this.m_WeaponEntity.m_iClip = ammo;
                 else
                     this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iPrimaryAmmoType, ammo );
+                totalAmmo = this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iPrimaryAmmoType );
+                maxAmmo = this.m_WeaponEntity.iMaxAmmo1();
                 break;
             }
             case AttackType::Secondary:
             {
                 this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iSecondaryAmmoType, ammo );
+                totalAmmo = this.m_Player.m_rgAmmo( this.m_WeaponEntity.m_iSecondaryAmmoType );
+                maxAmmo = this.m_WeaponEntity.iMaxAmmo2();
                 break;
             }
         }
 
-        if( ammo <= 0 && util::IsHEV( this.m_Player ) )
+        if( util::IsHEV( this.m_Player ) )
         {
-            this.m_Player.SetSuitUpdate( "!HEV_AMO0", false, 0 );
+            if( ammo <= 0 )
+            {
+                this.m_Weapon.PlaySound( "fvox/ammo_depleted.wav", 1.0f );
+            }
+            else if( totalAmmo < maxAmmo / 4 )
+            {
+                dictionary@ data = this.m_Player.GetUserData();
+
+                float lastAmmoNotice;
+                string keyName = "HEV_lowammo_" + this.m_WeaponEntity.GetClassname();
+
+                if( !data.get( keyName, lastAmmoNotice ) || lastAmmoNotice < g_Engine.time )
+                {
+                    data[ keyName ] = g_Engine.time + 60.0f;
+                    this.m_Weapon.PlaySound( "bts_rc/fvox/ammowarning.wav", 1.0f );
+                }
+            }
         }
     }
 

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
@@ -137,6 +137,7 @@ final class ASBullet
 
                 damage = config.primary_damage;
                 coneAccuracy = weapons::Accuracy( player, config.primary_accuracy, isTrainedPersonal );
+                weapons::Kickback( player, config.primary_kickback, isTrainedPersonal );
                 break;
             }
             case AttackType::Secondary:
@@ -144,6 +145,7 @@ final class ASBullet
                 player.m_rgAmmo( weapon.m_iSecondaryAmmoType, --ammo );
                 damage = config.secondary_damage;
                 coneAccuracy = weapons::Accuracy( player, config.secondary_accuracy, isTrainedPersonal );
+                weapons::Kickback( player, config.secondary_kickback, isTrainedPersonal );
             }
         }
 
@@ -189,8 +191,6 @@ final class ASBullet
         g_SoundSystem.EmitSoundDyn( weapon.edict(), SOUND_CHANNEL::CHAN_WEAPON, this.m_SoundName, this.m_Volume, this.m_Attenuation, 0, this.m_Pitch );
 
         weapon.SendWeaponAnim( Animation, 0, weaponClass.body );
-
-        AttackKickback( player, attackType );
 
         player.SetAnimation( PLAYER_ANIM::PLAYER_ATTACK1 );
 

--- a/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
+++ b/scripts/maps/bts_rc/entities/weapons/base/shared/bullet.as
@@ -1,17 +1,17 @@
 /**
 *   Copyright (c) 2026 Mikk155 and contributors of bts_rc
-*   
+*
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software to use, copy, modify, merge, publish, distribute, sublicense,
 *   and/or sell copies of the Software under the following conditions:
-*   
+*
 *   A reference to the original project must be included in all copies or substantial
 *   portions of the Software. This must include, at minimum, a URL to:
 *   https://github.com/Mikk155/bts_rc
-*   
+*
 *   The above copyright notice and this permission notice shall be included in all
 *   copies of the Software when distributed as a whole.
-*   
+*
 *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
 **/
 
@@ -137,7 +137,6 @@ final class ASBullet
 
                 damage = config.primary_damage;
                 coneAccuracy = weapons::Accuracy( player, config.primary_accuracy, isTrainedPersonal );
-                weapons::Kickback( player, config.primary_kickback, isTrainedPersonal );
                 break;
             }
             case AttackType::Secondary:
@@ -145,7 +144,6 @@ final class ASBullet
                 player.m_rgAmmo( weapon.m_iSecondaryAmmoType, --ammo );
                 damage = config.secondary_damage;
                 coneAccuracy = weapons::Accuracy( player, config.secondary_accuracy, isTrainedPersonal );
-                weapons::Kickback( player, config.secondary_kickback, isTrainedPersonal );
             }
         }
 
@@ -193,6 +191,19 @@ final class ASBullet
         weapon.SendWeaponAnim( Animation, 0, weaponClass.body );
 
         player.SetAnimation( PLAYER_ANIM::PLAYER_ATTACK1 );
+
+        switch( attackType )
+        {
+            case AttackType::Primary:
+            {
+                weapons::Kickback( player, config.primary_kickback, isTrainedPersonal );
+                break;
+            }
+            case AttackType::Secondary:
+            {
+                weapons::Kickback( player, config.secondary_kickback, isTrainedPersonal );
+            }
+        }
 
         this.Clear();
     }

--- a/scripts/maps/bts_rc/entities/weapons/config/ASWeaponConfig.as
+++ b/scripts/maps/bts_rc/entities/weapons/config/ASWeaponConfig.as
@@ -1,17 +1,17 @@
 /**
 *   Copyright (c) 2026 Mikk155 and contributors of bts_rc
-*   
+*
 *   Permission is hereby granted, free of charge, to any person obtaining a copy
 *   of this software to use, copy, modify, merge, publish, distribute, sublicense,
 *   and/or sell copies of the Software under the following conditions:
-*   
+*
 *   A reference to the original project must be included in all copies or substantial
 *   portions of the Software. This must include, at minimum, a URL to:
 *   https://github.com/Mikk155/bts_rc
-*   
+*
 *   The above copyright notice and this permission notice shall be included in all
 *   copies of the Software when distributed as a whole.
-*   
+*
 *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED.
 **/
 
@@ -158,8 +158,8 @@ bool ASWeaponConfigSchema = g_MapConfig.RegisterSchemaDefinition( "ASWeaponConfi
     {
         "type": "object",
         "unevaluatedProperties": false,
-        "title": "Weapon aim accuracy",
-        "description": "weapon accuracy modifiers.",
+        "title": "Weapon accuracy",
+        "description": "weapon kickback modifiers.",
         "properties":
         {
             "force": { "type": "boolean", "description": "if true the values are set, if false the values are added and accumulated." },
@@ -175,8 +175,8 @@ bool ASWeaponConfigSchema = g_MapConfig.RegisterSchemaDefinition( "ASWeaponConfi
     {
         "type": "object",
         "unevaluatedProperties": false,
-        "title": "Weapon aim accuracy",
-        "description": "weapon accuracy modifiers.",
+        "title": "Weapon kickback",
+        "description": "weapon kickback modifiers.",
         "properties":
         {
             "force": { "type": "boolean", "description": "if true the values are set, if false the values are added and accumulated." },

--- a/scripts/maps/bts_rc/entities/weapons/config/ASWeaponConfig.as
+++ b/scripts/maps/bts_rc/entities/weapons/config/ASWeaponConfig.as
@@ -196,6 +196,8 @@ abstract class ASWeaponConfig : IConfigurable
     const string& get_primary_ammoentity() { return String::EMPTY_STRING; }
     const string& get_secondary_ammo() { return String::EMPTY_STRING; }
     const string& get_secondary_ammoentity() { return String::EMPTY_STRING; }
+    // Set vector punch angle modifier
+    const AttackKickback( CBasePlayer@ player, AttackType attackType ) { }
 
     private int m_view_model_index = -1;
     // Do not override. is automatic.

--- a/scripts/maps/bts_rc/entities/weapons/config/ASWeaponConfig.as
+++ b/scripts/maps/bts_rc/entities/weapons/config/ASWeaponConfig.as
@@ -154,6 +154,40 @@ bool ASWeaponConfigSchema = g_MapConfig.RegisterSchemaDefinition( "ASWeaponConfi
             "run_trained": { "type": "number", "minimum": 0.001 }
         }
     },
+    "primary_kickback":
+    {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "title": "Weapon aim accuracy",
+        "description": "weapon accuracy modifiers.",
+        "properties":
+        {
+            "force": { "type": "boolean", "description": "if true the values are set, if false the values are added and accumulated." },
+            "stand": { "type": "number", "minimum": 0.001 },
+            "stand_trained": { "type": "number", "minimum": 0.001 },
+            "crouch": { "type": "number", "minimum": 0.001 },
+            "crouch_trained": { "type": "number", "minimum": 0.001 },
+            "run": { "type": "number", "minimum": 0.001 },
+            "run_trained": { "type": "number", "minimum": 0.001 }
+        }
+    },
+    "secondary_kickback":
+    {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "title": "Weapon aim accuracy",
+        "description": "weapon accuracy modifiers.",
+        "properties":
+        {
+            "force": { "type": "boolean", "description": "if true the values are set, if false the values are added and accumulated." },
+            "stand": { "type": "number", "minimum": 0.001 },
+            "stand_trained": { "type": "number", "minimum": 0.001 },
+            "crouch": { "type": "number", "minimum": 0.001 },
+            "crouch_trained": { "type": "number", "minimum": 0.001 },
+            "run": { "type": "number", "minimum": 0.001 },
+            "run_trained": { "type": "number", "minimum": 0.001 }
+        }
+    },
     "reload_time":
     {
         "type": "number"
@@ -196,8 +230,6 @@ abstract class ASWeaponConfig : IConfigurable
     const string& get_primary_ammoentity() { return String::EMPTY_STRING; }
     const string& get_secondary_ammo() { return String::EMPTY_STRING; }
     const string& get_secondary_ammoentity() { return String::EMPTY_STRING; }
-    // Set vector punch angle modifier
-    const AttackKickback( CBasePlayer@ player, AttackType attackType ) { }
 
     private int m_view_model_index = -1;
     // Do not override. is automatic.
@@ -216,12 +248,16 @@ abstract class ASWeaponConfig : IConfigurable
     int primary_dropammo = WEAPON_NOCLIP;
     // Accuracy for primary attacks
     float[] primary_accuracy(6);
+    // Kickback for primary attacks
+    float[] primary_kickback(7);
     // Weapon secondary max ammo capacity. automatically set in BTS_Weapon::GetItemInfo
     int secondary_maxammo = WEAPON_NOCLIP;
     // Weapon secondary max ammo drop. automatically set in BTS_Weapon::GetItemInfo
     int secondary_dropammo = WEAPON_NOCLIP;
     // Accuracy for secondary attacks
     float[] secondary_accuracy(6);
+    // Kickback for secondary attacks
+    float[] secondary_kickback(7);
     // Weapon primary max ammo clip capacity. automatically set in BTS_Weapon::GetItemInfo
     int max_clip = WEAPON_NOCLIP;
     // Weapon hud slot. automatically set in BTS_Weapon::GetItemInfo
@@ -321,7 +357,7 @@ abstract class ASWeaponConfig : IConfigurable
             g_Game.PrecacheGeneric( szSpriteDir );
         }
     }
- 
+
     // Precache required assets
     void Precache()
     {
@@ -421,6 +457,32 @@ abstract class ASWeaponConfig : IConfigurable
             this.secondary_accuracy[3] = accuracy.ValueOrDefault( "crouch_trained", this.secondary_accuracy[2], false, false );
             this.secondary_accuracy[4] = accuracy.ValueOrDefault( "run", this.secondary_accuracy[3], false, false );
             this.secondary_accuracy[5] = accuracy.ValueOrDefault( "run_trained", this.secondary_accuracy[4], false, false );
+        }
+
+        meta_api::json::v2::json@ kickback = config[ "primary_kickback" ];
+
+        if( kickback !is null )
+        {
+            this.primary_kickback[0] = kickback.ValueOrDefault( "stand", 0.001, false, false );
+            this.primary_kickback[1] = kickback.ValueOrDefault( "stand_trained", this.primary_kickback[0], false, false );
+            this.primary_kickback[2] = kickback.ValueOrDefault( "crouch", this.primary_kickback[1], false, false );
+            this.primary_kickback[3] = kickback.ValueOrDefault( "crouch_trained", this.primary_kickback[2], false, false );
+            this.primary_kickback[4] = kickback.ValueOrDefault( "run", this.primary_kickback[3], false, false );
+            this.primary_kickback[5] = kickback.ValueOrDefault( "run_trained", this.primary_kickback[4], false, false );
+            this.primary_kickback[6] = kickback.ValueOrDefault( "force", 0, false, false );
+        }
+
+        @kickback = config[ "secondary_kickback" ];
+
+        if( kickback !is null )
+        {
+            this.secondary_kickback[0] = kickback.ValueOrDefault( "stand", 0.001, false, false );
+            this.secondary_kickback[1] = kickback.ValueOrDefault( "stand_trained", this.secondary_kickback[0], false, false );
+            this.secondary_kickback[2] = kickback.ValueOrDefault( "crouch", this.secondary_kickback[1], false, false );
+            this.secondary_kickback[3] = kickback.ValueOrDefault( "crouch_trained", this.secondary_kickback[2], false, false );
+            this.secondary_kickback[4] = kickback.ValueOrDefault( "run", this.secondary_kickback[3], false, false );
+            this.secondary_kickback[5] = kickback.ValueOrDefault( "run_trained", this.secondary_kickback[4], false, false );
+            this.secondary_kickback[6] = kickback.ValueOrDefault( "force", 0, false, false );
         }
 
         // Reload properties

--- a/scripts/maps/bts_rc/entities/weapons/config/ASWeaponLightConfig.as
+++ b/scripts/maps/bts_rc/entities/weapons/config/ASWeaponLightConfig.as
@@ -334,7 +334,8 @@ abstract class ASWeaponLightConfig : ASWeaponConfig
 
             weapon.m_fInReload = false;
             data[ this.GetName() ] = Battery = this.secondary_dropammo;
-            player.m_rgAmmo( Flashlight::GetAmmoIndex(), ammoCount - 1 );
+            if( !g_WeaponsConfig.infinite_ammo )
+                player.m_rgAmmo( Flashlight::GetAmmoIndex(), ammoCount - 1 );
             data.delete( "flashlight_reload" );
             weapons::Deploy( weapon, player, this );
             weapon.pev.fuser1 = weapon.m_flNextSecondaryAttack;
@@ -378,7 +379,7 @@ abstract class ASWeaponLightConfig : ASWeaponConfig
                 {
                     float nextDrain = float( data[ "flashlight_nextdrain" ] );
 
-                    if( nextDrain <= g_Engine.time )
+                    if( nextDrain <= g_Engine.time && !g_WeaponsConfig.infinite_ammo )
                     {
                         data[ "flashlight_nextdrain" ] = g_Engine.time + flashlight_drain;
 

--- a/scripts/maps/bts_rc/entities/weapons/main.as
+++ b/scripts/maps/bts_rc/entities/weapons/main.as
@@ -20,6 +20,7 @@
 #include "base/shared/bullet"
 #include "base/shared/Deploy"
 #include "base/shared/Hit"
+#include "base/shared/Kickback"
 #include "base/shared/SetCooldown"
 #include "base/shared/TraceEffects"
 
@@ -198,7 +199,7 @@ final class ASGlobalWeaponConfig : IConfigurable
 
                 auto remap = ItemMapping( classFrom, classTo );
                 g_WeaponsConfig.ItemMappingList.insertLast( @remap );
-                
+
                 if( g_Logger.info.active )
                 {
                     g_Logger.info.print( "Adding ItemMapping \"{}\" -> \"{}\"", { classFrom, classTo } );

--- a/scripts/maps/bts_rc/entities/weapons/main.as
+++ b/scripts/maps/bts_rc/entities/weapons/main.as
@@ -17,6 +17,7 @@
 
 // Shared functions
 #include "base/shared/Accuracy"
+#include "base/shared/bullet"
 #include "base/shared/Deploy"
 #include "base/shared/Hit"
 #include "base/shared/SetCooldown"

--- a/scripts/maps/bts_rc/entities/weapons/main.as
+++ b/scripts/maps/bts_rc/entities/weapons/main.as
@@ -83,6 +83,7 @@ final class ASGlobalWeaponConfig : IConfigurable
 {
     bool melee_weapons_pull;
     float melee_weapons_pull_force;
+    bool infinite_ammo;
     bool melee_weapons_push;
     float melee_weapons_push_force;
     bool blood_splash;
@@ -108,6 +109,11 @@ final class ASGlobalWeaponConfig : IConfigurable
                 {
                     "type": "boolean",
                     "description": "Allow melee weapons to pull allied players."
+                },
+                "infinite_ammo":
+                {
+                    "type": "boolean",
+                    "description": "Weapons has infinite ammo. made for testing firing."
                 },
                 "melee_weapons_pull_force":
                 {
@@ -185,6 +191,7 @@ final class ASGlobalWeaponConfig : IConfigurable
         this.blood_splash = bool( config[ "blood_splash" ] );
         this.m249_knockback = bool( config[ "m249_knockback" ] );
         this.flashlight_maxcarry = int( config[ "flashlight_maxcarry" ] );
+        this.infinite_ammo = bool( config[ "infinite_ammo" ] );
 
         // ItemMapping stuff
         if( g_MapConfig.MapLoading )
@@ -212,6 +219,16 @@ final class ASGlobalWeaponConfig : IConfigurable
 
             // Free object
             this.ItemMappingList.resize(0);
+
+            RegisterCommand( "infinite_ammo", "<int 0/1 (optional)>", "Toggle infinite ammunition mode",
+                @CommandCallback( function( CBasePlayer@ player, array<string>@ arguments )
+                {
+                    if( arguments !is null && arguments.length() > 0 )
+                        g_WeaponsConfig.infinite_ammo = ( atoi( arguments[0] ) != 0 );
+                    else
+                        g_WeaponsConfig.infinite_ammo = !g_WeaponsConfig.infinite_ammo;
+                    g_PlayerFuncs.ClientPrint( player, HUD_PRINTCONSOLE, "Infinite ammo has been " + ( g_WeaponsConfig.infinite_ammo ? "activated\n" : "deactivated\n" ) );
+                } ), true, "weapon" );
         }
 
         return true;

--- a/scripts/maps/bts_rc/schema.json
+++ b/scripts/maps/bts_rc/schema.json
@@ -9,6 +9,11 @@
 				"type": "string",
 				"description": "Reference to the JSON schema file used for validation and editor hinting."
 			},
+			"allow_reload": 
+			{
+				"type": "boolean",
+				"description": "When true the map scripts will keep json schemas in memory and register a command to reload json files run time."
+			},
 			"logger": 
 			{
 				"type": "object",
@@ -283,8 +288,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -328,8 +333,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -595,8 +600,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -640,8 +645,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -913,8 +918,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -958,8 +963,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -1227,8 +1232,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -1272,8 +1277,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -1545,8 +1550,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -1590,8 +1595,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -1863,8 +1868,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -1908,8 +1913,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2180,8 +2185,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2225,8 +2230,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2491,8 +2496,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2536,8 +2541,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2802,8 +2807,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2847,8 +2852,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -2944,6 +2949,56 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"default": 
+						{
+							"stand": 2.5,
+							"stand_trained": 2
+						},
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -3140,57 +3195,12 @@
 							}
 						}
 					},
-					"primary_kickback": 
-					{
-						"type": "object",
-						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
-						"properties": 
-						{
-							"force": 
-							{
-								"type": "boolean",
-								"description": "if true the values are set, if false the values are added and accumulated."
-							},
-							"stand": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"stand_trained": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"crouch": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"crouch_trained": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"run": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"run_trained": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							}
-						}
-					},
 					"secondary_kickback": 
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -3315,6 +3325,56 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"default": 
+						{
+							"stand": 11,
+							"stand_trained": 4
+						},
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -3503,57 +3563,12 @@
 							}
 						}
 					},
-					"primary_kickback": 
-					{
-						"type": "object",
-						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
-						"properties": 
-						{
-							"force": 
-							{
-								"type": "boolean",
-								"description": "if true the values are set, if false the values are added and accumulated."
-							},
-							"stand": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"stand_trained": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"crouch": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"crouch_trained": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"run": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							},
-							"run_trained": 
-							{
-								"type": "number",
-								"minimum": 0.001
-							}
-						}
-					},
 					"secondary_kickback": 
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -3837,8 +3852,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -3882,8 +3897,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -4167,8 +4182,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -4212,8 +4227,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -4507,8 +4522,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -4552,8 +4567,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -4858,8 +4873,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -4903,8 +4918,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -5160,8 +5175,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -5205,8 +5220,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -5488,8 +5503,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -5533,8 +5548,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -5806,8 +5821,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -5851,8 +5866,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -6127,8 +6142,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -6172,8 +6187,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -6448,8 +6463,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -6493,8 +6508,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -6769,8 +6784,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -6814,8 +6829,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -7083,8 +7098,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -7128,8 +7143,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -7397,8 +7412,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -7442,8 +7457,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -7714,8 +7729,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -7759,8 +7774,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8031,8 +8046,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8076,8 +8091,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8330,8 +8345,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8375,8 +8390,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8641,8 +8656,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8686,8 +8701,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -8955,8 +8970,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9000,8 +9015,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9302,8 +9317,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9347,8 +9362,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9616,8 +9631,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9661,8 +9676,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9925,8 +9940,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -9970,8 +9985,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -10228,8 +10243,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -10273,8 +10288,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -10537,8 +10552,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -10582,8 +10597,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -10848,8 +10863,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -10893,8 +10908,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -11157,8 +11172,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -11202,8 +11217,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -11476,8 +11491,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -11521,8 +11536,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -11789,8 +11804,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -11834,8 +11849,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -12101,8 +12116,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon accuracy",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -12146,8 +12161,8 @@
 					{
 						"type": "object",
 						"unevaluatedProperties": false,
-						"title": "Weapon aim accuracy",
-						"description": "weapon accuracy modifiers.",
+						"title": "Weapon kickback",
+						"description": "weapon kickback modifiers.",
 						"properties": 
 						{
 							"force": 
@@ -12239,6 +12254,12 @@
 						"type": "boolean",
 						"description": "Allow melee weapons to pull allied players.",
 						"default": true
+					},
+					"infinite_ammo": 
+					{
+						"type": "boolean",
+						"description": "Weapons has infinite ammo. made for testing firing.",
+						"default": false
 					},
 					"melee_weapons_pull_force": 
 					{

--- a/scripts/maps/bts_rc/schema.json
+++ b/scripts/maps/bts_rc/schema.json
@@ -2981,6 +2981,21 @@
 							}
 						}
 					},
+					"primary_cooldown": 
+					{
+						"default": 0.1,
+						"type": "number"
+					},
+					"primary_damage": 
+					{
+						"default": 15,
+						"type": "number"
+					},
+					"primary_dropammo": 
+					{
+						"default": 15,
+						"type": "integer"
+					},
 					"primary_kickback": 
 					{
 						"default": 
@@ -3030,21 +3045,6 @@
 								"minimum": 0.001
 							}
 						}
-					},
-					"primary_cooldown": 
-					{
-						"default": 0.1,
-						"type": "number"
-					},
-					"primary_damage": 
-					{
-						"default": 15,
-						"type": "number"
-					},
-					"primary_dropammo": 
-					{
-						"default": 15,
-						"type": "integer"
 					},
 					"primary_maxammo": 
 					{
@@ -3357,6 +3357,21 @@
 							}
 						}
 					},
+					"primary_cooldown": 
+					{
+						"default": 0.22,
+						"type": "number"
+					},
+					"primary_damage": 
+					{
+						"default": 65,
+						"type": "number"
+					},
+					"primary_dropammo": 
+					{
+						"default": 3,
+						"type": "integer"
+					},
 					"primary_kickback": 
 					{
 						"default": 
@@ -3406,21 +3421,6 @@
 								"minimum": 0.001
 							}
 						}
-					},
-					"primary_cooldown": 
-					{
-						"default": 0.22,
-						"type": "number"
-					},
-					"primary_damage": 
-					{
-						"default": 65,
-						"type": "number"
-					},
-					"primary_dropammo": 
-					{
-						"default": 3,
-						"type": "integer"
 					},
 					"primary_maxammo": 
 					{

--- a/scripts/maps/bts_rc/schema.json
+++ b/scripts/maps/bts_rc/schema.json
@@ -279,6 +279,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -469,6 +559,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -729,6 +909,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -921,6 +1191,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -1181,6 +1541,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -1377,6 +1827,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -1636,6 +2176,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -1825,6 +2455,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -2078,6 +2798,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -2298,6 +3108,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -2603,6 +3503,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_sound": 
 					{
 						"type": "string"
@@ -2843,6 +3833,96 @@
 					{
 						"type": "number"
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -3051,6 +4131,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -3301,6 +4471,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -3593,6 +4853,96 @@
 								"minimum": 0.001
 							}
 						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
 					}
 				}
 			},
@@ -3774,6 +5124,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -4044,6 +5484,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -4240,6 +5770,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -4503,6 +6123,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -4702,6 +6412,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -4965,6 +6765,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -5189,6 +7079,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -5381,6 +7361,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -5640,6 +7710,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -5867,6 +8027,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -6044,6 +8294,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -6297,6 +8637,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -6489,6 +8919,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -6778,6 +9298,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -6970,6 +9580,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -7221,6 +9921,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -7402,6 +10192,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -7621,6 +10501,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -7874,6 +10844,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -8061,6 +11121,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",
@@ -8322,6 +11472,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -8545,6 +11785,96 @@
 							}
 						}
 					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
 					"reload_time": 
 					{
 						"type": "number"
@@ -8735,6 +12065,96 @@
 						"description": "weapon accuracy modifiers.",
 						"properties": 
 						{
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"primary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
+							"stand": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"stand_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"crouch_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							},
+							"run_trained": 
+							{
+								"type": "number",
+								"minimum": 0.001
+							}
+						}
+					},
+					"secondary_kickback": 
+					{
+						"type": "object",
+						"unevaluatedProperties": false,
+						"title": "Weapon aim accuracy",
+						"description": "weapon accuracy modifiers.",
+						"properties": 
+						{
+							"force": 
+							{
+								"type": "boolean",
+								"description": "if true the values are set, if false the values are added and accumulated."
+							},
 							"stand": 
 							{
 								"type": "number",

--- a/scripts/maps/bts_rc/util/CommandContext.as
+++ b/scripts/maps/bts_rc/util/CommandContext.as
@@ -116,7 +116,7 @@ CClientCommand __CommandContextCallback__( "bts_rc", "bts_rc commands", function
         {
             if( args.ArgC() < 3 || args[1] != context.Section || args[2] != context.Command )
                 continue;
-            start = 1;
+            start = 3;
         }
 
         if( context.Lambda !is null )

--- a/scripts/maps/bts_rc/util/Precache.as
+++ b/scripts/maps/bts_rc/util/Precache.as
@@ -246,6 +246,7 @@ void Precache()
     g_SoundSystem.PrecacheSound( "bullchicken/bc_bite3.wav" );
     g_SoundSystem.PrecacheSound( "debris/beamstart4.wav" );
     g_SoundSystem.PrecacheSound( "debris/beamstart7.wav" );
+    g_SoundSystem.PrecacheSound( "fvox/ammo_depleted.wav" );
     g_SoundSystem.PrecacheSound( "headcrab/hc_headbite.wav" );
     g_SoundSystem.PrecacheSound( "hlclassic/weapons/357_cock1.wav" );
     g_SoundSystem.PrecacheSound( "hlclassic/weapons/357_reload1.wav" );

--- a/scripts/maps/bts_rc/util/utils.as
+++ b/scripts/maps/bts_rc/util/utils.as
@@ -25,7 +25,7 @@
 
 #include "../../../mikk155/SemanticVersion"
 
-const SemanticVersion@ g_ScriptsVersion = SemVer( 4, 3, 1 );
+const SemanticVersion@ g_ScriptsVersion = SemVer( 4, 4, 0 );
 
 // Whatever the current map is bts_rc
 const bool g_IsMainMap = ( string( g_Engine.mapname ) == "bts_rc" );

--- a/src/Tests/cache.json
+++ b/src/Tests/cache.json
@@ -1,10 +1,10 @@
 {
     "modified": {
-        "docs/assets/credits.json": "2026-08-04 21:24:43",
-        "scripts/maps/bts_rc/util/utils.as": "2026-08-08 13:48:51",
+        "docs/assets/credits.json": "2026-08-10 12:01:57",
+        "scripts/maps/bts_rc/util/utils.as": "2026-08-10 12:03:11",
         "scripts/maps/bts_rc/entities/weapons/default_config.json": "2026-07-26 18:22:23",
         "src/precaches.json": "2026-08-06 18:51:02",
-        "TODO.md": "2026-08-08 13:48:15",
+        "TODO.md": "2026-08-09 10:54:14",
         "scripts/maps/bts_rc/default_config.json": "2026-08-08 13:00:34"
     }
 }

--- a/src/Tests/cache.json
+++ b/src/Tests/cache.json
@@ -4,7 +4,7 @@
         "scripts/maps/bts_rc/util/utils.as": "2026-08-10 15:09:33",
         "scripts/maps/bts_rc/entities/weapons/default_config.json": "2026-07-26 18:22:23",
         "src/precaches.json": "2026-08-06 18:51:02",
-        "TODO.md": "2026-08-10 21:29:03",
-        "scripts/maps/bts_rc/default_config.json": "2026-08-10 21:14:20"
+        "TODO.md": "2026-08-11 18:46:41",
+        "scripts/maps/bts_rc/default_config.json": "2026-08-10 21:29:36"
     }
 }

--- a/src/Tests/cache.json
+++ b/src/Tests/cache.json
@@ -1,10 +1,10 @@
 {
     "modified": {
         "docs/assets/credits.json": "2026-08-10 12:01:57",
-        "scripts/maps/bts_rc/util/utils.as": "2026-08-10 12:40:40",
+        "scripts/maps/bts_rc/util/utils.as": "2026-08-10 15:09:33",
         "scripts/maps/bts_rc/entities/weapons/default_config.json": "2026-07-26 18:22:23",
         "src/precaches.json": "2026-08-06 18:51:02",
-        "TODO.md": "2026-08-10 12:40:19",
-        "scripts/maps/bts_rc/default_config.json": "2026-08-10 12:34:13"
+        "TODO.md": "2026-08-10 21:29:03",
+        "scripts/maps/bts_rc/default_config.json": "2026-08-10 21:14:20"
     }
 }

--- a/src/Tests/cache.json
+++ b/src/Tests/cache.json
@@ -3,8 +3,8 @@
         "docs/assets/credits.json": "2026-08-10 12:01:57",
         "scripts/maps/bts_rc/util/utils.as": "2026-08-10 15:09:33",
         "scripts/maps/bts_rc/entities/weapons/default_config.json": "2026-07-26 18:22:23",
-        "src/precaches.json": "2026-08-06 18:51:02",
-        "TODO.md": "2026-08-11 18:46:41",
+        "src/precaches.json": "2026-08-11 19:17:42",
+        "TODO.md": "2026-08-11 19:11:22",
         "scripts/maps/bts_rc/default_config.json": "2026-08-10 21:29:36"
     }
 }

--- a/src/precaches.json
+++ b/src/precaches.json
@@ -82,6 +82,7 @@
         "bullchicken/bc_bite3.wav",
         "debris/beamstart4.wav",
         "debris/beamstart7.wav",
+        "fvox/ammo_depleted.wav",
         "headcrab/hc_headbite.wav",
         "hlclassic/weapons/357_cock1.wav",
         "hlclassic/weapons/357_reload1.wav",


### PR DESCRIPTION
## Description
Declares a global class ``bullet`` which supports pattern method calling to set up a "bullet" i.e set sound, shells, model, animation, all with default values while providing a Fire method to call at the end of the build-pattern to shoot the bullet with all the configuration.

## Related Issues
Links to any issues resolved or related:
- Closes #94 
- Closes #20 
- Closes #80 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Optimization / Refactor (improving codebase efficiency or structure)
- [ ] Documentation update (improving guides, wiki, or comments)

## Checklist
- [x] My code follows the code style guidelines of this project (Allman braces, spacing inside parentheses).
- [x] I have run `python src/main.py` to ensure all script files have been validated.
- [x] I have updated ``CHANGELOG.md`` according to our [rules](https://github.com/Mikk155/bts_rc/wiki/changelog)
- [x] I have checked ``svencoop/scripts/maps/store/bts_rc.log`` to see there is not any logger entry with ``Critical`` or ``Error`` level.
- [x] I have updated ``g_ScriptsVersion`` at ``scripts/maps/bts_rc/util/utils.as`` according to [Semantic versioning](https://semver.org/)
